### PR TITLE
Corrects the spelling of "wun"

### DIFF
--- a/dec64.asm.html
+++ b/dec64.asm.html
@@ -177,10 +177,12 @@ th:after {
 <ul>
   <li><code>DEC64_NAN</code></li>
   <li><code>DEC64_ZERO</code></li>
-  <li><code>DEC64_ONE</code></li>
-  <li><code>DEC64_NEGATIVE_ONE</code></li>
+  <li><code>DEC64_WUN</code></li>
+  <li><code>DEC64_ONE</code> (deprecated in favor of DEC64_WUN)</li>
+  <li><code>DEC64_NEGATIVE_WUN</code></li>
+  <li><code>DEC64_NEGATIVE_ONE</code> (deprecated in favor of DEC64_NEGATIVE_WUN)</li>
 </ul>
-<p>The comparison functions will return either <code>DEC64_ONE</code> or <code>DEC64_ZERO</code>.</p>
+<p>The comparison functions will return either <code>DEC64_WUN</code> or <code>DEC64_ZERO</code>.</p>
 <h2 id="nan"><var>nan</var></h2>
 <p><var>nan (not-a-number)</var> is a popular but poorly named concept in
     floating-point systems. It is a number value that represents numbers that
@@ -298,7 +300,7 @@ dec64_subtract(<var>nan</var>, <var>n</var>)</pre>
     <var>difference</var>: dec64</h3>
 <p>The decrement function subtracts <code>1</code> from a number. That can be
     faster than </p>
-<pre>dec64_subtract(<var>augend</var>, DEC64_ONE)</pre>
+<pre>dec64_subtract(<var>augend</var>, DEC64_WUN)</pre>
 <h3 id="dec64_divide">dec64_divide(<var>dividend</var>: dec64,
     <var>divisor</var>: dec64) returns <var>quotient</var>: dec64</h3>
 <p>This function divides the <var>dividend</var> by the <var>divisor</var>.</p>
@@ -307,7 +309,7 @@ dec64_subtract(<var>nan</var>, <var>n</var>)</pre>
     dec64</h3>
 <p>Compare two  numbers. If either is <var>nan</var>, return
     <code>DEC64_NAN</code>. If they are exactly equal, return
-    <code>DEC64_ONE</code>, otherwise return <code>DEC64_ZERO</code>. Denormal
+    <code>DEC64_WUN</code>, otherwise return <code>DEC64_ZERO</code>. Denormal
     zeros are equal but denormal nans are not.</p>
 <h3 id="dec64_exponent">dec64_exponent(<var>number</var>: dec64)
     returns <var>exponent</var>: int64</h3>
@@ -338,7 +340,7 @@ dec64_subtract(<var>nan</var>, <var>n</var>)</pre>
     <var>sum</var>: dec64</h3>
 <p>The increment function adds <code>1</code> to a number. That can be faster
     than </p>
-<pre>dec64_add(<var>augend</var>, DEC64_ONE)</pre>
+<pre>dec64_add(<var>augend</var>, DEC64_WUN)</pre>
 <h3 id="dec64_int">dec64_int(<var>number</var>: dec64) returns
     <var>integer</var>: dec64</h3>
 <p>Convert the number such that the exponent will be zero, discarding the
@@ -356,16 +358,16 @@ dec64_subtract(<var>nan</var>, <var>n</var>)</pre>
 <h3 id="dec64_is_any_nan">dec64_is_any_nan(<var>number</var>: dec64)
     returns <var>comparison</var>: dec64</h3>
 <p>If the <var>number</var> is any <var>nan</var>, return
-    <code>DEC64_ONE</code>, otherwise return <code>DEC64_ZERO</code>. To test
+    <code>DEC64_WUN</code>, otherwise return <code>DEC64_ZERO</code>. To test
     if a <var>number</var> is the normal <code>DEC64_NAN</code>, just use <code>==</code>.</p>
 <h3 id="dec64_is_integer">dec64_is_integer(<var>number</var>: dec64)
     returns <var>comparison</var>: dec64</h3>
 <p>If the <var>number</var> contains a non-zero fractional part or if it is
     <var>nan</var>, return <code>DEC64_ZERO</code>. Otherwise, return
-    <code>DEC64_ONE</code>.</p>
+    <code>DEC64_WUN</code>.</p>
 <h3 id="dec64_is_zero">dec64_is_zero(<var>number</var>: dec64)
     returns <var>comparison</var>: dec64</h3>
-<p>If the <var>number</var> is any zero, return <code>DEC64_ONE</code>,
+<p>If the <var>number</var> is any zero, return <code>DEC64_WUN</code>,
     otherwise return <code>DEC64_ZERO</code>. To test if a <var>number</var>
     is <code>DEC64_ZERO</code>, use <code>==</code>.</p>
 <h3 id="dec64_less">dec64_less(<var>comparahend</var>: dec64,
@@ -373,7 +375,7 @@ dec64_subtract(<var>nan</var>, <var>n</var>)</pre>
     dec64</h3>
 <p>Compare two  numbers. If either argument is any <var>nan</var>, then the
     result is <code>DEC64_NAN</code>. If the <var>comparahend</var> is less
-    than the <var>comparator</var>, return <code>DEC64_ONE</code>, otherwise
+    than the <var>comparator</var>, return <code>DEC64_WUN</code>, otherwise
     return <code>DEC64_ZERO</code>.</p>
 <p>The other 3 comparison functions are easily implemented with
     <code>dec64_less</code>:</p>
@@ -418,9 +420,9 @@ dec64_less_or_equal(<var>a</var>, <var>b</var>)    =&gt; dec64_not(dec64_less(<v
     it does not materially change the value of a number.</p>
 <h3 id="dec64_not">dec64_not(<var>boolean</var>: dec64) returns
     <var>notation</var>: dec64</h3>
-<p>If the <var>boolean</var> is <code>DEC64_ONE</code>, the result is
+<p>If the <var>boolean</var> is <code>DEC64_WUN</code>, the result is
     <code>DEC64_ZERO</code>. If the <var>boolean</var> is
-    <code>DEC64_ZERO</code>, the result is <code>DEC64_ONE</code>. Otherwise,
+    <code>DEC64_ZERO</code>, the result is <code>DEC64_WUN</code>. Otherwise,
     the result is <code>DEC64_NAN</code>.</p>
 <h3 id="dec64_round">dec64_round(<var>number</var>: dec64,
     <var>place</var>: dec64) returns <var>quantization</var>:
@@ -457,9 +459,9 @@ dec64_less_or_equal(<var>a</var>, <var>b</var>)    =&gt; dec64_not(dec64_less(<v
     <var>signature</var>: dec64</h3>
 <p>If the number is <var>nan</var>, the result is <code>DEC64_NAN</code>.
     If the number is less than zero, the result is
-    <code>DEC64_NEGATIVE_ONE</code>. If the number is zero, the result is
+    <code>DEC64_NEGATIVE_WUN</code>. If the number is zero, the result is
     <code>DEC64_ZERO</code>. If the number is greater than zero, the result is
-    <code>DEC64_ONE</code>.</p>
+    <code>DEC64_WUN</code>.</p>
 <h3 id="dec64_subtract">dec64_subtract(<var>minuend</var>: dec64,
     <var>subtrahend</var>: dec64) returns <var>difference</var>:
     dec64</h3>

--- a/dec64.h
+++ b/dec64.h
@@ -11,7 +11,9 @@ No warranty.
 
 #define DEC64_NAN           (0x80LL)
 #define DEC64_ZERO          (0x00LL)
+#define DEC64_WUN           (0x100LL)
 #define DEC64_ONE           (0x100LL)
+#define DEC64_NEGATIVE_WUN  (0xFFFFFFFFFFFFFF00LL)
 #define DEC64_NEGATIVE_ONE  (0xFFFFFFFFFFFFFF00LL)
 
 typedef long long int64;

--- a/dec64_math.c
+++ b/dec64_math.c
@@ -132,15 +132,15 @@ dec64 dec64_acos(dec64 slope) {
 }
 
 dec64 dec64_asin(dec64 slope) {
-    if (dec64_equal(slope, DEC64_ONE) == DEC64_ONE) {
+    if (dec64_equal(slope, DEC64_WUN) == DEC64_WUN) {
         return D_HALF_PI;
     }
-    if (dec64_equal(slope, DEC64_NEGATIVE_ONE) == DEC64_ONE) {
+    if (dec64_equal(slope, DEC64_NEGATIVE_WUN) == DEC64_WUN) {
         return D_NHALF_PI;
     }
     if (
-        dec64_is_any_nan(slope) == DEC64_ONE ||
-        dec64_less(DEC64_ONE, dec64_abs(slope)) == DEC64_ONE
+        dec64_is_any_nan(slope) == DEC64_WUN ||
+        dec64_less(DEC64_WUN, dec64_abs(slope)) == DEC64_WUN
     ) {
         return DEC64_NAN;
     }
@@ -179,8 +179,8 @@ dec64 dec64_atan(dec64 slope) {
 }
 
 dec64 dec64_atan2(dec64 y, dec64 x) {
-    if (dec64_is_zero(x) == DEC64_ONE) {
-        if (dec64_is_zero(y) == DEC64_ONE) {
+    if (dec64_is_zero(x) == DEC64_WUN) {
+        if (dec64_is_zero(y) == DEC64_WUN) {
             return DEC64_NAN;
         } else if (y < 0) {
             return D_NHALF_PI;
@@ -225,27 +225,27 @@ dec64 dec64_exp(dec64 exponent) {
 }
 
 dec64 dec64_exponentiate(dec64 coefficient, dec64 exponent) {
-    if (dec64_is_zero(exponent) == DEC64_ONE) {
-        return DEC64_ONE;
+    if (dec64_is_zero(exponent) == DEC64_WUN) {
+        return DEC64_WUN;
     }
 
 // Adjust for a negative exponent.
 
     if (exponent < 0) {
-        coefficient = dec64_divide(DEC64_ONE, coefficient);
+        coefficient = dec64_divide(DEC64_WUN, coefficient);
         exponent = dec64_neg(exponent);
     }
-    if (dec64_is_any_nan(coefficient) == DEC64_ONE) {
+    if (dec64_is_any_nan(coefficient) == DEC64_WUN) {
         return DEC64_NAN;
     }
-    if (dec64_is_zero(coefficient) == DEC64_ONE) {
+    if (dec64_is_zero(coefficient) == DEC64_WUN) {
         return 0;
     }
 
 // If the exponent is an integer, then use the squaring method.
 
     if (exponent > 0 && dec64_exponent(exponent) == 0) {
-        dec64 aux = DEC64_ONE;
+        dec64 aux = DEC64_WUN;
         int64 n = dec64_coefficient(exponent);
         if (n <= 1) {
             return coefficient;
@@ -280,17 +280,17 @@ dec64 dec64_factorial(dec64 x) {
 }
 
 dec64 dec64_log(dec64 x) {
-    if (x <= 0 || dec64_is_any_nan(x) == DEC64_ONE) {
+    if (x <= 0 || dec64_is_any_nan(x) == DEC64_WUN) {
         return DEC64_NAN;
     }
-    if (dec64_equal(x, DEC64_ONE) == DEC64_ONE) {
+    if (dec64_equal(x, DEC64_WUN) == DEC64_WUN) {
         return DEC64_ZERO;
     }
-    if (dec64_equal(x, D_HALF) == DEC64_ONE) {
+    if (dec64_equal(x, D_HALF) == DEC64_WUN) {
         return dec64_new(-6931471805599453, -16);
     }
     if (x == D_E) {
-        return DEC64_ONE;
+        return DEC64_WUN;
     }
     dec64 y = dec64_divide(dec64_dec(x), x);
     dec64 factor = y;
@@ -347,8 +347,8 @@ dec64 dec64_root(dec64 index, dec64 radicand) {
     dec64 result;
     index = dec64_normal(index);
     if (
-        dec64_is_any_nan(radicand) == DEC64_ONE
-        || dec64_is_zero(index) == DEC64_ONE
+        dec64_is_any_nan(radicand) == DEC64_WUN
+        || dec64_is_zero(index) == DEC64_WUN
         || index < 0
         || dec64_exponent(index) != 0
         || (
@@ -358,25 +358,25 @@ dec64 dec64_root(dec64 index, dec64 radicand) {
     ) {
         return DEC64_NAN;
     }
-    if (dec64_is_zero(radicand) == DEC64_ONE) {
+    if (dec64_is_zero(radicand) == DEC64_WUN) {
         return DEC64_ZERO;
     }
-    if (index == DEC64_ONE) {
+    if (index == DEC64_WUN) {
         return radicand;
     }
     if (index == D_2) {
         return dec64_sqrt(radicand);
     }
-    dec64 index_minus_one = dec64_dec(index);
-    result = DEC64_ONE;
+    dec64 index_minus_wun = dec64_dec(index);
+    result = DEC64_WUN;
     dec64 prosult = DEC64_NAN;
     while (1) {
         dec64 progress = dec64_divide(
             dec64_add(
-                dec64_multiply(result, index_minus_one),
+                dec64_multiply(result, index_minus_wun),
                 dec64_divide(
                     radicand,
-                    dec64_exponentiate(result, index_minus_one)
+                    dec64_exponentiate(result, index_minus_wun)
                 )
             ),
             index
@@ -402,11 +402,11 @@ void dec64_seed(dec64 seed) {
 }
 
 dec64 dec64_sin(dec64 radians) {
-    while (dec64_less(D_PI, radians) == DEC64_ONE) {
+    while (dec64_less(D_PI, radians) == DEC64_WUN) {
         radians = dec64_subtract(radians, D_PI);
         radians = dec64_subtract(radians, D_PI);
     }
-    while (dec64_less(radians, D_NPI) == DEC64_ONE) {
+    while (dec64_less(radians, D_NPI) == DEC64_WUN) {
         radians = dec64_add(radians, D_PI);
         radians = dec64_add(radians, D_PI);
     }
@@ -415,15 +415,15 @@ dec64 dec64_sin(dec64 radians) {
         radians = dec64_neg(radians);
         neg = -1;
     }
-    if (dec64_less(D_HALF_PI, radians) == DEC64_ONE) {
+    if (dec64_less(D_HALF_PI, radians) == DEC64_WUN) {
         radians = dec64_subtract(D_PI, radians);
     }
     dec64 result;
     if (radians == D_HALF_PI) {
-        result = DEC64_ONE;
+        result = DEC64_WUN;
     } else {
         dec64 x2 = dec64_multiply(radians, radians);
-        dec64 order = DEC64_ONE;
+        dec64 order = DEC64_WUN;
         dec64 term = radians;
         result = term;
         while (1) {
@@ -454,7 +454,7 @@ dec64 dec64_sin(dec64 radians) {
 }
 
 dec64 dec64_sqrt(dec64 radicand) {
-    if (dec64_is_any_nan(radicand) != DEC64_ONE && radicand >= 0) {
+    if (dec64_is_any_nan(radicand) != DEC64_WUN && radicand >= 0) {
         if (dec64_coefficient(radicand) == 0) {
             return DEC64_ZERO;
         }

--- a/dec64_math_test.c
+++ b/dec64_math_test.c
@@ -27,7 +27,7 @@ static dec64 nan;
 static dec64 nannan;
 static dec64 zero;
 static dec64 zip;
-static dec64 one;
+static dec64 wun;
 static dec64 two;
 static dec64 three;
 static dec64 four;
@@ -44,13 +44,13 @@ static dec64 maxnum;
 static dec64 minnum;
 static dec64 e;
 static dec64 epsilon;
-static dec64 almost_one;
-static dec64 almost_negative_one;
+static dec64 almost_wun;
+static dec64 almost_negative_wun;
 static dec64 pi;
 static dec64 half_pi;
 static dec64 half;
 static dec64 cent;
-static dec64 negative_one;
+static dec64 negative_wun;
 static dec64 negative_nine;
 static dec64 negative_minnum;
 static dec64 negative_maxint;
@@ -62,7 +62,7 @@ static void define_constants() {
     nannan = 32896;                 /* a non-normal nan */
     zero = DEC64_ZERO;              /* 0 */
     zip = 1;                        /* a non normal 0 */
-    one = DEC64_ONE;                /* 1 */
+    wun = DEC64_WUN;                /* 1 */
     two = dec64_new(2, 0);          /* 2 */
     three = dec64_new(3, 0);        /* 3 */
     four = dec64_new(4, 0);         /* 4 */
@@ -78,7 +78,7 @@ static void define_constants() {
     epsilon = dec64_new(1, -16);    /* the smallest number addable to 1 */
     cent = dec64_new(1, -2);        /* 0.01 */
     half = dec64_new(5, -1);        /* 0.5 */
-    almost_one = dec64_new(9999999999999999, -16);
+    almost_wun = dec64_new(9999999999999999, -16);
                                     /* 0.9999999999999999 */
     pi = dec64_new(31415926535897932, -16);
                                     /* pi */
@@ -91,7 +91,7 @@ static void define_constants() {
                                     /* the largest possible number */
     negative_minnum = dec64_new(-1, -127);
                                     /* the smallest possible negative number */
-    negative_one = dec64_new(-1, 0);/* -1 */
+    negative_wun = dec64_new(-1, 0);/* -1 */
     negative_nine = dec64_new(-9, 0);
                                     /* -9 */
     negative_pi = dec64_new(-31415926535897932, -16);
@@ -100,14 +100,14 @@ static void define_constants() {
                                     /* the largest negative normal integer */
     negative_maxnum = dec64_new(-36028797018963968, 127);
                                     /* the largest possible negative number */
-    almost_negative_one = dec64_new(-9999999999999999, -16);
+    almost_negative_wun = dec64_new(-9999999999999999, -16);
                                     /* -0.9999999999999999 */
 }
 
 
 static void print_dec64(dec64 number) {
     dec64_string_char actual[32];
-    if (dec64_is_any_nan(number) == DEC64_ONE) {
+    if (dec64_is_any_nan(number) == DEC64_WUN) {
         printf("nan");
     } else {
         dec64_to_string(state, number, actual);
@@ -126,14 +126,14 @@ void p(dec64 number, dec64_string_char name[]) {
 }
 
 static void judge_unary(
-    dec64 first, 
-    dec64 expected, 
-    dec64 actual, 
-    char * name, 
-    char * op, 
+    dec64 first,
+    dec64 expected,
+    dec64 actual,
+    char * name,
+    char * op,
     char * comment
 ) {
-    if (dec64_equal(expected, actual) == DEC64_ONE) {
+    if (dec64_equal(expected, actual) == DEC64_WUN) {
         nr_pass += 1;
         if (level >= 3) {
             printf("\n\npass %s: %s", name, comment);
@@ -161,15 +161,15 @@ static void judge_unary(
 }
 
 static void judge_binary(
-    dec64 first, 
-    dec64 second, 
-    dec64 expected, 
-    dec64 actual, 
-    char * name, 
-    char * op, 
+    dec64 first,
+    dec64 second,
+    dec64 expected,
+    dec64 actual,
+    char * name,
+    char * op,
     char * comment
 ) {
-    if (dec64_equal(expected, actual) == DEC64_ONE) {
+    if (dec64_equal(expected, actual) == DEC64_WUN) {
         nr_pass += 1;
         if (level >= 3) {
             printf("\n\npass %s: %s\n    ", name, comment);
@@ -260,31 +260,31 @@ static void test_tan(dec64 first, dec64 expected, char * comment) {
 }
 
 static void test_all_acos() {
-    test_acos(negative_one, pi, "-1");
+    test_acos(negative_wun, pi, "-1");
     test_acos(zero, half_pi, "0");
     test_acos(epsilon, dec64_new(15707963267948965, -16), "epsilon");
     test_acos(cent, dec64_new(15607961601207295, -16), "0.01");
     test_acos(half, dec64_new(10471975511965977, -16), "0.5");
-    test_acos(one, zero, "1");
+    test_acos(wun, zero, "1");
     test_acos(half_pi, nan, "pi/2");
 }
 
 static void test_all_asin() {
-    test_asin(negative_one, dec64_neg(half_pi), "-1");
+    test_asin(negative_wun, dec64_neg(half_pi), "-1");
     test_asin(zero, zero, "0");
     test_asin(epsilon, epsilon, "epsilon");
     test_asin(cent, dec64_new(10000166674167113, -18), "0.01");
     test_asin(half, dec64_new(5235987755982989, -16), "0.5");
-    test_asin(one, half_pi, "1");
+    test_asin(wun, half_pi, "1");
     test_asin(half_pi, nan, "pi/2");
 }
 
 static void test_all_atan() {
-    test_atan(DEC64_NEGATIVE_ONE, dec64_new(-7853981633974483, -16), "-1");
+    test_atan(DEC64_NEGATIVE_WUN, dec64_new(-7853981633974483, -16), "-1");
     test_atan(zero, zero, "0");
     test_atan(cent, dec64_new(9999666686665238, -18), "1/100");
     test_atan(half, dec64_new(4636476090008061, -16), "1/2");
-    test_atan(one, dec64_new(7853981633974483, -16), "1");
+    test_atan(wun, dec64_new(7853981633974483, -16), "1");
     test_atan(half_pi, dec64_new(10038848218538872, -16), "pi/2");
     test_atan(e, dec64_new(12182829050172776, -16), "e");
     test_atan(pi, dec64_new(12626272556789117, -16), "pi");
@@ -292,27 +292,27 @@ static void test_all_atan() {
 }
 
 static void test_all_cos() {
-    test_cos(zero, one, "0");
+    test_cos(zero, wun, "0");
     test_cos(cent, dec64_new(99995000041666528, -17), "0.01");
-    test_cos(pi, negative_one, "pi");
+    test_cos(pi, negative_wun, "pi");
     test_cos(half_pi, zero, "pi");
     test_cos(ten, dec64_new(-8390715290764525, -16), "10");
 }
 
 static void test_all_exp() {
-    test_exp(zero, one, "0");
+    test_exp(zero, wun, "0");
     test_exp(cent, dec64_new(10100501670841681, -16), "0.01");
     test_exp(half, dec64_new(16487212707001281, -16), "0.5");
-    test_exp(one, e, "1");
+    test_exp(wun, e, "1");
     test_exp(two,  dec64_new(7389056098930650, -15), "2");
     test_exp(ten,  dec64_new(22026465794806717, -12), "10");
 }
 
 static void test_all_exponentiate() {
-    test_exponentiate(e, zero, one, "e^0");
+    test_exponentiate(e, zero, wun, "e^0");
     test_exponentiate(e, cent, dec64_new(10100501670841681, -16), "e^0.01");
     test_exponentiate(e, half, dec64_new(16487212707001281, -16), "e^0.5");
-    test_exponentiate(e, one, e, "e^1");
+    test_exponentiate(e, wun, e, "e^1");
     test_exponentiate(e, two,  dec64_new(7389056098930650, -15), "e^2");
     test_exponentiate(e, ten,  dec64_new(22026465794806717, -12), "e^10");
     test_exponentiate(four, half,  two, "4^0.5");
@@ -323,8 +323,8 @@ static void test_all_exponentiate() {
 }
 
 static void test_all_factorial() {
-    test_factorial(zero, one, "0!");
-    test_factorial(one, one, "1!");
+    test_factorial(zero, wun, "0!");
+    test_factorial(wun, wun, "1!");
     test_factorial(dec64_new(18, 0), dec64_new(6402373705728000, 0), "18!");
     test_factorial(dec64_new(19, 0), dec64_new(121645100408832000, 0), "19!");
     test_factorial(dec64_new(20, 0), dec64_new(2432902008176640000, 0), "20!");
@@ -334,17 +334,17 @@ static void test_all_factorial() {
     test_factorial(dec64_new(93, 0), nan, "93!");
     test_factorial(nan, nan, "nan!");
     test_factorial(pi, nan, "pi!");
-    test_factorial(negative_one, nan, "-1!");
+    test_factorial(negative_wun, nan, "-1!");
 }
 
 static void test_all_log() {
     test_log(zero, nan, "0");
     test_log(cent, dec64_new(-4605170185988091, -16), "0.01");
     test_log(half, dec64_new(-6931471805599453, -16), "1/2");
-    test_log(one, zero, "1");
+    test_log(wun, zero, "1");
     test_log(half_pi, dec64_new(4515827052894549, -16), "pi/2");
     test_log(two, dec64_new(6931471805599453, -16), "2");
-    test_log(e, one, "e");
+    test_log(e, wun, "e");
     test_log(pi, dec64_new(11447298858494002, -16), "pi");
     test_log(ten, dec64_new(23025850929940457, -16), "10");
 }
@@ -354,7 +354,7 @@ static void test_all_root() {
     test_root(three, zero, zero, "3|zero");
     test_root(three, half, dec64_new(7937005259840997, -16), "3|1/2");
     test_root(three, dec64_new(27, 0), three, "3|27");
-    test_root(three, dec64_new(-27, 0), dec64_new(-3, 0), "3|-27");    
+    test_root(three, dec64_new(-27, 0), dec64_new(-3, 0), "3|-27");
     test_root(three, pi, dec64_new(14645918875615233, -16), "3|pi");
     test_root(four, dec64_new(-27, 0), nan, "4|-27");
     test_root(four, dec64_new(256, 0), four, "4|256");
@@ -367,8 +367,8 @@ static void test_all_sin() {
     test_sin(zero, zero, "0");
     test_sin(epsilon, epsilon, "epsilon");
     test_sin(cent, dec64_new(9999833334166665, -18), "0.01");
-    test_sin(one, dec64_new(8414709848078965, -16), "1");
-    test_sin(half_pi, one, "pi/2");
+    test_sin(wun, dec64_new(8414709848078965, -16), "1");
+    test_sin(half_pi, wun, "pi/2");
     test_sin(two, dec64_new(9092974268256817, -16), "2");
     test_sin(e, dec64_new(4107812905029087, -16), "e");
     test_sin(three, dec64_new(14112000805986722, -17), "3");
@@ -383,7 +383,7 @@ static void test_all_sqrt() {
     test_sqrt(zero, zero, "0");
     test_sqrt(half, dec64_new(7071067811865475, -16), "1/2");
     test_sqrt(two, dec64_new(14142135623730950, -16), "2");
-    test_sqrt(one, one, "1");
+    test_sqrt(wun, wun, "1");
     test_sqrt(pi, dec64_new(17724538509055160, -16), "pi");
     test_sqrt(dec64_new(10, 0), dec64_new(31622776601683793, -16), "10");
     test_sqrt(dec64_new(16, 0), dec64_new(4, 0), "16");
@@ -396,7 +396,7 @@ static void test_all_tan() {
     test_tan(zero, zero, "0");
     test_tan(cent, dec64_new(10000333346667206, -18), "0.01");
     test_tan(half, dec64_new(5463024898437905, -16), "1/2");
-    test_tan(one, dec64_new(15574077246549022, -16), "1");
+    test_tan(wun, dec64_new(15574077246549022, -16), "1");
     test_tan(half_pi, nan, "pi/2");
     test_tan(pi, zero, "pi");
     test_tan(ten, dec64_new(6483608274590867, -16), "10");

--- a/dec64_string.c
+++ b/dec64_string.c
@@ -79,9 +79,9 @@ static emit(dec64_string_state state, int c) {
 
 static void emit_at(dec64_string_state state, int64 at) {
     emit(
-        state, 
+        state,
         (at >= state->nr_digits || at < 0)
-            ? '0' 
+            ? '0'
             : state->digits[at]
     );
 }
@@ -231,7 +231,7 @@ static void standard(dec64_string_state state) {
 
 dec64_string_state dec64_string_begin() {
 /*
-    Create a state object. State objects are passed as the first argument to 
+    Create a state object. State objects are passed as the first argument to
     the other public functions. It holds state so that this module is reentrant
     and thread safe. Do not manipulate this object directly. Use the functions.
     It can return NULL if memory allocation fails.
@@ -282,7 +282,7 @@ void dec64_string_engineering(dec64_string_state state) {
 void dec64_string_scientific(dec64_string_state state) {
 /*
     Put dec64_to_string into scientific mode, in which the coefficient is
-    displayed with one digit before the decimal point, and an exponent 
+    displayed with wun digit before the decimal point, and an exponent
     prefixed with 'e' is appended if necessary.
 */
     state->mode = scientific_mode;
@@ -371,7 +371,7 @@ dec64_string_char dec64_string_separator(
 /* Action. */
 
 dec64 dec64_from_string(
-    dec64_string_state state, 
+    dec64_string_state state,
     dec64_string_char string[]
 ) {
 /*
@@ -459,7 +459,7 @@ dec64 dec64_from_string(
                 leading = 0;
 /*
     Count the number of digits. Only accumulate the first 18 digits. The most
-    we can use is 17. We take one more for rounding.
+    we can use is 17. We take wun more for rounding.
 */
                 digits += 1;
                 if (digits > 18) {
@@ -478,7 +478,7 @@ dec64 dec64_from_string(
                     exponent -= point;
                 }
 /*
-    There is a decimal point. If there is more than one decimal
+    There is a decimal point. If there is more than wun decimal
     point, return nan.
 */
             } else if (c == state->decimal_point) {
@@ -581,8 +581,8 @@ int dec64_to_string(
 
     state->length = 0;
     state->string = string;
-    if (dec64_is_any_nan(number) != DEC64_ONE) {
-        if (dec64_is_zero(number) == DEC64_ONE) {
+    if (dec64_is_any_nan(number) != DEC64_WUN) {
+        if (dec64_is_zero(number) == DEC64_WUN) {
             emit(state, '0');
         } else {
             if (number != state->number) {

--- a/dec64_string_test.c
+++ b/dec64_string_test.c
@@ -26,7 +26,7 @@ static dec64 nan;
 static dec64 nannan;
 static dec64 zero;
 static dec64 zip;
-static dec64 one;
+static dec64 wun;
 static dec64 two;
 static dec64 three;
 static dec64 four;
@@ -41,12 +41,12 @@ static dec64 maxint_plus;
 static dec64 maxnum;
 static dec64 minnum;
 static dec64 epsilon;
-static dec64 almost_one;
-static dec64 almost_negative_one;
+static dec64 almost_wun;
+static dec64 almost_negative_wun;
 static dec64 pi;
 static dec64 half;
 static dec64 cent;
-static dec64 negative_one;
+static dec64 negative_wun;
 static dec64 negative_nine;
 static dec64 negative_minnum;
 static dec64 negative_maxint;
@@ -58,7 +58,7 @@ static void define_constants() {
     nannan = 32896;                 /* a non-normal nan */
     zero = DEC64_ZERO;              /* 0 */
     zip = 1;                        /* a non normal 0 */
-    one = DEC64_ONE;                /* 1 */
+    wun = DEC64_WUN;                /* 1 */
     two = dec64_new(2, 0);          /* 2 */
     three = dec64_new(3, 0);        /* 3 */
     four = dec64_new(4, 0);         /* 4 */
@@ -72,7 +72,7 @@ static void define_constants() {
     epsilon = dec64_new(1, -16);    /* the smallest number addable to 1 */
     cent = dec64_new(1, -2);        /* 0.01 */
     half = dec64_new(5, -1);        /* 0.5 */
-    almost_one = dec64_new(9999999999999999, -16);
+    almost_wun = dec64_new(9999999999999999, -16);
     								/* 0.9999999999999999 */
     pi = dec64_new(31415926535897932, -16);
     								/* pi */
@@ -84,7 +84,7 @@ static void define_constants() {
     								/* the largest possible number */
     negative_minnum = dec64_new(-1, -127);
     								/* the smallest possible negative number */
-    negative_one = dec64_new(-1, 0);/* -1 */
+    negative_wun = dec64_new(-1, 0);/* -1 */
     negative_nine = dec64_new(-9, 0);
     								/* -9 */
     negative_pi = dec64_new(-31415926535897932, -16);
@@ -93,7 +93,7 @@ static void define_constants() {
     								/* the largest negative normal integer */
     negative_maxnum = dec64_new(-36028797018963968, 127);
     								/* the largest possible negative number */
-    almost_negative_one = dec64_new(-9999999999999999, -16);
+    almost_negative_wun = dec64_new(-9999999999999999, -16);
     								/* -0.9999999999999999 */
 }
 
@@ -111,7 +111,7 @@ static void print_dec64(dec64 number) {
 
 static void test_from(dec64_string_char * string, dec64 expected) {
     dec64 actual = dec64_from_string(state, string);
-    if (dec64_equal(expected, actual) == DEC64_ONE) {
+    if (dec64_equal(expected, actual) == DEC64_WUN) {
         nr_pass += 1;
         if (level >= 3) {
             printf("\n\npass from: %s", string);
@@ -160,7 +160,7 @@ static void test_to_standard() {
     test_to(nannan, "");
     test_to(zero, "0");
     test_to(zip, "0");
-    test_to(one, "1");
+    test_to(wun, "1");
     test_to(two, "2");
     test_to(three, "3");
     test_to(four, "4");
@@ -175,12 +175,12 @@ static void test_to_standard() {
     test_to(maxnum, "3.6028797018963967e143");
     test_to(minnum, "1e-127");
     test_to(epsilon, "0.0000000000000001");
-    test_to(almost_one, "0.9999999999999999");
-    test_to(almost_negative_one, "-0.9999999999999999");
+    test_to(almost_wun, "0.9999999999999999");
+    test_to(almost_negative_wun, "-0.9999999999999999");
     test_to(pi, "3.1415926535897932");
     test_to(half, "0.5");
     test_to(cent, "0.01");
-    test_to(negative_one, "-1");
+    test_to(negative_wun, "-1");
     test_to(negative_nine, "-9");
     test_to(negative_minnum, "-1e-127");
     test_to(negative_maxint, "-36028797018963968");
@@ -196,7 +196,7 @@ static void test_to_separated() {
     test_to(nannan, "");
     test_to(zero, "0");
     test_to(zip, "0");
-    test_to(one, "1");
+    test_to(wun, "1");
     test_to(two, "2");
     test_to(three, "3");
     test_to(four, "4");
@@ -211,12 +211,12 @@ static void test_to_separated() {
     test_to(maxnum, "3.6028797018963967e143");
     test_to(minnum, "1e-127");
     test_to(epsilon, "0.0000000000000001");
-    test_to(almost_one, "0.9999999999999999");
-    test_to(almost_negative_one, "-0.9999999999999999");
+    test_to(almost_wun, "0.9999999999999999");
+    test_to(almost_negative_wun, "-0.9999999999999999");
     test_to(pi, "3.1415926535897932");
     test_to(half, "0.5");
     test_to(cent, "0.01");
-    test_to(negative_one, "-1");
+    test_to(negative_wun, "-1");
     test_to(negative_nine, "-9");
     test_to(negative_minnum, "-1e-127");
     test_to(negative_maxint, "-36,028,797,018,963,968");
@@ -238,7 +238,7 @@ static void test_to_place() {
     test_to(nannan, "");
     test_to(zero, "0");
     test_to(zip, "0");
-    test_to(one, "1.00");
+    test_to(wun, "1.00");
     test_to(two, "2.00");
     test_to(three, "3.00");
     test_to(four, "4.00");
@@ -253,12 +253,12 @@ static void test_to_place() {
     test_to(maxnum, "3.6028797018963967e143");
     test_to(minnum, "1e-127");
     test_to(epsilon, "0.0000000000000001");
-    test_to(almost_one, "0.9999999999999999");
-    test_to(almost_negative_one, "-0.9999999999999999");
+    test_to(almost_wun, "0.9999999999999999");
+    test_to(almost_negative_wun, "-0.9999999999999999");
     test_to(pi, "3.1415926535897932");
     test_to(half, "0.50");
     test_to(cent, "0.01");
-    test_to(negative_one, "-1.00");
+    test_to(negative_wun, "-1.00");
     test_to(negative_nine, "-9.00");
     test_to(negative_minnum, "-1e-127");
     test_to(negative_maxint, "-36,028,797,018,963,968.00");
@@ -297,7 +297,7 @@ static void test_to_scientific() {
     test_to(nannan, "");
     test_to(zero, "0");
     test_to(zip, "0");
-    test_to(one, "1");
+    test_to(wun, "1");
     test_to(two, "2");
     test_to(three, "3");
     test_to(four, "4");
@@ -312,12 +312,12 @@ static void test_to_scientific() {
     test_to(maxnum, "3.6028797018963967e143");
     test_to(minnum, "1e-127");
     test_to(epsilon, "1e-16");
-    test_to(almost_one, "9.999999999999999e-1");
-    test_to(almost_negative_one, "-9.999999999999999e-1");
+    test_to(almost_wun, "9.999999999999999e-1");
+    test_to(almost_negative_wun, "-9.999999999999999e-1");
     test_to(pi, "3.1415926535897932");
     test_to(half, "5e-1");
     test_to(cent, "1e-2");
-    test_to(negative_one, "-1");
+    test_to(negative_wun, "-1");
     test_to(negative_nine, "-9");
     test_to(negative_minnum, "-1e-127");
     test_to(negative_maxint, "-3.6028797018963968e16");
@@ -359,7 +359,7 @@ static void test_to_engineering() {
     test_to(nannan, "");
     test_to(zero, "0");
     test_to(zip, "0");
-    test_to(one, "1");
+    test_to(wun, "1");
     test_to(two, "2");
     test_to(three, "3");
     test_to(four, "4");
@@ -374,12 +374,12 @@ static void test_to_engineering() {
     test_to(maxnum, "360.28797018963967e141");
     test_to(minnum, "100e-129");
     test_to(epsilon, "100e-18");
-    test_to(almost_one, "999.9999999999999e-3");
-    test_to(almost_negative_one, "-999.9999999999999e-3");
+    test_to(almost_wun, "999.9999999999999e-3");
+    test_to(almost_negative_wun, "-999.9999999999999e-3");
     test_to(pi, "3.1415926535897932");
     test_to(half, "500e-3");
     test_to(cent, "10e-3");
-    test_to(negative_one, "-1");
+    test_to(negative_wun, "-1");
     test_to(negative_nine, "-9");
     test_to(negative_minnum, "-100e-129");
     test_to(negative_maxint, "-36.028797018963968e15");
@@ -436,13 +436,13 @@ static void test_all_from() {
     test_from("0.00", zero);
     test_from("0.00e-999", zero);
 
-    test_from("1", one);
-    test_from("01", one);
-    test_from("1.00", one);
-    test_from("1e+00", one);
-    test_from(".100e00000000001", one);
-    test_from("1.00e0000000000", one);
-    test_from("10.00e-00000000001", one);
+    test_from("1", wun);
+    test_from("01", wun);
+    test_from("1.00", wun);
+    test_from("1e+00", wun);
+    test_from(".100e00000000001", wun);
+    test_from("1.00e0000000000", wun);
+    test_from("10.00e-00000000001", wun);
 
 
     test_from("2", two);
@@ -474,16 +474,16 @@ static void test_all_from() {
     test_from("1e-16", epsilon);
     test_from("100e-18", epsilon);
 
-    test_from("999.9999999999999e-3", almost_one);
-    test_from("9.999999999999999e-1", almost_one);
-    test_from(".9999999999999999", almost_one);
-    test_from("0.999999999999999900000000000000", almost_one);
-    test_from("0.9999999999999999", almost_one);
-    test_from("-999.9999999999999e-3", almost_negative_one);
-    test_from("-9.999999999999999e-1", almost_negative_one);
-    test_from("-.9999999999999999", almost_negative_one);
-    test_from("-0.9999999999999999", almost_negative_one);
-    test_from("-000000000000000000000000.999999999999999900000000000000000", almost_negative_one);
+    test_from("999.9999999999999e-3", almost_wun);
+    test_from("9.999999999999999e-1", almost_wun);
+    test_from(".9999999999999999", almost_wun);
+    test_from("0.999999999999999900000000000000", almost_wun);
+    test_from("0.9999999999999999", almost_wun);
+    test_from("-999.9999999999999e-3", almost_negative_wun);
+    test_from("-9.999999999999999e-1", almost_negative_wun);
+    test_from("-.9999999999999999", almost_negative_wun);
+    test_from("-0.9999999999999999", almost_negative_wun);
+    test_from("-000000000000000000000000.999999999999999900000000000000000", almost_negative_wun);
     test_from("3.1415926535897932", pi);
     test_from("31415926535897932E-16", pi);
     test_from("-3.1415926535897932", negative_pi);
@@ -495,8 +495,8 @@ static void test_all_from() {
     test_from("10e-3", cent);
     test_from("1e-2", cent);
     test_from("0.01", cent);
-    test_from("-1", negative_one);
-    test_from("-1.00", negative_one);
+    test_from("-1", negative_wun);
+    test_from("-1.00", negative_wun);
     test_from("-9E-0000000000000000000000", negative_nine);
     test_from("-9.00", negative_nine);
     test_from("-1e-127", negative_minnum);

--- a/dec64_test.c
+++ b/dec64_test.c
@@ -13,7 +13,7 @@ No warranty.
 #include "dec64.h"
 
 #define false DEC64_ZERO
-#define true DEC64_ONE
+#define true DEC64_WUN
 
 static int level;
 static int nr_fail;
@@ -25,7 +25,7 @@ static dec64 nan;
 static dec64 nannan;
 static dec64 zero;
 static dec64 zip;
-static dec64 one;
+static dec64 wun;
 static dec64 two;
 static dec64 three;
 static dec64 four;
@@ -43,13 +43,13 @@ static dec64 googol;
 static dec64 minnum;
 static dec64 negative_epsilon;
 static dec64 epsilon;
-static dec64 almost_one;
-static dec64 almost_negative_one;
+static dec64 almost_wun;
+static dec64 almost_negative_wun;
 static dec64 e;
 static dec64 pi;
 static dec64 half;
 static dec64 cent;
-static dec64 negative_one;
+static dec64 negative_wun;
 static dec64 negative_nine;
 static dec64 negative_minnum;
 static dec64 negative_maxint;
@@ -61,7 +61,7 @@ static void define_constants() {
     nannan = 32896;                                         /* a non-normal nan */
     zero = DEC64_ZERO;                                      /* 0 */
     zip = 250;                                              /* a non normal 0 */
-    one = DEC64_ONE;                						/* 1 */
+    wun = DEC64_WUN;                						/* 1 */
     two = dec64_new(2, 0);          						/* 2 */
     three = dec64_new(3, 0);        						/* 3 */
     four = dec64_new(4, 0);         						/* 4 */
@@ -77,23 +77,23 @@ static void define_constants() {
 
     cent = dec64_new(1, -2);        						/* 0.01 */
     half = dec64_new(5, -1);        						/* 0.5 */
-    almost_one = dec64_new(9999999999999999, -16);          /* 0.9999999999999999 */
+    almost_wun = dec64_new(9999999999999999, -16);          /* 0.9999999999999999 */
     e = dec64_new(27182818284590452, -16);                  /* e */
     pi = dec64_new(31415926535897932, -16);                 /* pi */
 
     maxint = dec64_new(36028797018963967, 0);               /* the largest normal integer */
     maxint_plus = dec64_new(3602879701896397, 1);           /* the smallest number larger than maxint */
-    one_over_maxint = dec64_new(27755575615628914, -33);    /* one / maxint */
+    one_over_maxint = dec64_new(27755575615628914, -33);    /* wun / maxint */
     maxnum = dec64_new(36028797018963967, 127);             /* the largest possible number */
     googol = dec64_new(1, 100);                             /* googol */
 
     negative_minnum = dec64_new(-1, -127);                  /* the smallest possible negative number */
-    negative_one = dec64_new(-1, 0);                        /* -1 */
+    negative_wun = dec64_new(-1, 0);                        /* -1 */
     negative_nine = dec64_new(-9, 0);                       /* -9 */
     negative_pi = dec64_new(-31415926535897932, -16);       /* -pi */
     negative_maxint = dec64_new(-36028797018963968, 0);     /* the largest negative normal integer */
     negative_maxnum = dec64_new(-36028797018963968, 127);   /* the largest possible negative number */
-    almost_negative_one = dec64_new(-9999999999999999, -16);/* -0.9999999999999999 */
+    almost_negative_wun = dec64_new(-9999999999999999, -16);/* -0.9999999999999999 */
 }
 
 static void print_dec64(dec64 number) {
@@ -385,9 +385,9 @@ static void test_all_abs() {
     test_abs(zero, zero, "zero");
     test_abs(zip, zero, "zip");
     test_abs(100, zero, "zero alias");
-    test_abs(one, one, "one");
-    test_abs(negative_one, one, "-1");
-    test_abs(almost_negative_one, almost_one, "almost_negative_one");
+    test_abs(wun, wun, "wun");
+    test_abs(negative_wun, wun, "-1");
+    test_abs(almost_negative_wun, almost_wun, "almost_negative_wun");
     test_abs(negative_maxint, maxint_plus, "-maxint");
     test_abs(negative_maxnum, nan, "-maxnum");
     test_abs(maxnum, maxnum, "maxnum");
@@ -396,28 +396,28 @@ static void test_all_abs() {
 static void test_all_add() {
     test_add(nan, zero, nan, "nan + zero");
     test_add(nan, nan, nan, "nan + nan");
-    test_add(nannan, one, nan, "nannan + 1");
+    test_add(nannan, wun, nan, "nannan + 1");
     test_add(nannan, nannan, nan, "nannan + nannan");
     test_add(zero, nannan, nan, "0 + nannan");
     test_add(zero, zip, zero, "zero + zip");
     test_add(zip, zero, zero, "zip + zero");
     test_add(zip, zip, zero, "zip + zip");
-    test_add(almost_one, epsilon, one, "almost_one + epsilon");
-    test_add(almost_one, nine, ten, "almost_one + 1");
-    test_add(one, nan, nan, "one + nan");
-    test_add(one, one, two, "one + one");
-    test_add(one, cent, dec64_new(101, -2), "one + cent");
-    test_add(one, epsilon, dec64_new(10000000000000001, -16), "1 + epsilon");
+    test_add(almost_wun, epsilon, wun, "almost_wun + epsilon");
+    test_add(almost_wun, nine, ten, "almost_wun + 1");
+    test_add(wun, nan, nan, "wun + nan");
+    test_add(wun, wun, two, "wun + wun");
+    test_add(wun, cent, dec64_new(101, -2), "wun + cent");
+    test_add(wun, epsilon, dec64_new(10000000000000001, -16), "1 + epsilon");
     test_add(three, four, seven, "three + four");
     test_add(four, epsilon, dec64_new(4000000000000000, -15), "4 + epsilon");
     test_add(dec64_new(1, 2), dec64_new(-1, -2), dec64_new(9999, -2), "100 - 0.01");
     test_add(dec64_new(10, 10), dec64_new(20, 10), dec64_new(30, 10), "10e10 + 20e10");
     test_add(dec64_new(199, -2), dec64_new(299, -2), dec64_new(498, -2), "1.99 + 2.99");
     test_add(dec64_new(36028797018963967, 126), dec64_new(36028797018963967, 126), dec64_new(7205759403792793, 127), "test overflow with big exponents");
-    test_add(dec64_new(9999999999999999, 0), one, dec64_new(10000000000000000, 0), "9999999999999999 + 1");
-    test_add(negative_one, epsilon, almost_negative_one, "-1 + epsilon");
+    test_add(dec64_new(9999999999999999, 0), wun, dec64_new(10000000000000000, 0), "9999999999999999 + 1");
+    test_add(negative_wun, epsilon, almost_negative_wun, "-1 + epsilon");
     test_add(negative_pi, pi, zero, "-pi + pi");
-    test_add(maxint, one, maxint_plus, "maxint + one");
+    test_add(maxint, wun, maxint_plus, "maxint + wun");
     test_add(maxint, half, maxint_plus, "maxint + half");
     test_add(maxint, cent, maxint, "maxint + cent");
     test_add(maxint, dec64_new(4999999999, -11), maxint, "maxint + 0.4999999999");
@@ -428,7 +428,7 @@ static void test_all_add() {
     test_add(maxint, dec64_new(20000000000000000, -16), maxint_plus, "maxint + something too small");
     test_add(maxint, negative_maxint, dec64_new(-1, 0), "maxint + -maxint");
     test_add(maxnum, dec64_new(1, -127), maxnum, "insignificance");
-    test_add(maxnum, one, maxnum, "insignificance");
+    test_add(maxnum, wun, maxnum, "insignificance");
     test_add(maxnum, maxint, maxnum, "insignificance");
     test_add(maxnum, dec64_new(1, 127), nan, "overflow the exponent");
     test_add(maxnum, dec64_new(10, 126), nan, "overflow the exponent");
@@ -437,11 +437,11 @@ static void test_all_add() {
     test_add(maxnum, dec64_new(500, 124), nan, "overflow the exponent");
     test_add(maxnum, maxnum, nan, "overflow the exponent");
     test_add(maxnum, dec64_new(-36028797018963967, 127), zero, "extreme zero");
-    test_add(almost_negative_one, one, epsilon, "almost_negative_one + one");
-    test_add(almost_negative_one, almost_one, zero, "almost_negative_one + almost_one");
+    test_add(almost_negative_wun, wun, epsilon, "almost_negative_wun + wun");
+    test_add(almost_negative_wun, almost_wun, zero, "almost_negative_wun + almost_wun");
     test_add(dec64_new(1, -1), dec64_new(1, -3), dec64_new(101, -3), "0.1 + 0.001");
     test_add(dec64_new(1, -1), dec64_new(1, -17), dec64_new(10000000000000001, -17), "0.1 + 1e-16");
-    test_add(dec64_new(7182818284590704, -16), one, dec64_new(17182818284590704, -16), "7182818284590704e-16 + 1");
+    test_add(dec64_new(7182818284590704, -16), wun, dec64_new(17182818284590704, -16), "7182818284590704e-16 + 1");
     test_add(dec64_new(7182818284590704, -16), dec64_new(10, -1), dec64_new(17182818284590704, -16), "7182818284590704e-16 + 10e-1");
     test_add(dec64_new(4000000000000000, -16), dec64_new(10, -1), dec64_new(14000000000000000, -16), "4000000000000000e-16 + 10e-1");
     test_add(dec64_new(1, -1), dec64_new(2, -1), dec64_new(3, -1), "0.1 + 0.2");
@@ -452,14 +452,14 @@ static void test_all_ceiling() {
     test_ceiling(nannan, nan, "nannan");
     test_ceiling(zero, zero, "zero");
     test_ceiling(zip, zero, "zero");
-    test_ceiling(minnum, one, "minnum");
-    test_ceiling(epsilon, one, "epsilon");
-    test_ceiling(cent, one, "cent");
-    test_ceiling(half, one, "half");
-    test_ceiling(one, one, "one");
-    test_ceiling(negative_one, negative_one, "negative_one");
+    test_ceiling(minnum, wun, "minnum");
+    test_ceiling(epsilon, wun, "epsilon");
+    test_ceiling(cent, wun, "cent");
+    test_ceiling(half, wun, "half");
+    test_ceiling(wun, wun, "wun");
+    test_ceiling(negative_wun, negative_wun, "negative_wun");
     test_ceiling(dec64_new(10000000000000001, -16), two, "1.0000000000000001");
-    test_ceiling(dec64_new(-10000000000000001, -16), negative_one, "-1.0000000000000001");
+    test_ceiling(dec64_new(-10000000000000001, -16), negative_wun, "-1.0000000000000001");
     test_ceiling(dec64_new(20000000000000000, -16), two, "two");
     test_ceiling(e, three, "e");
     test_ceiling(pi, four, "pi");
@@ -467,15 +467,15 @@ static void test_all_ceiling() {
     test_ceiling(maxint, maxint, "maxint");
     test_ceiling(maxnum, maxnum, "maxnum");
     test_ceiling(negative_maxint, negative_maxint, "negative_maxint");
-    test_ceiling(dec64_new(11111111111111111, -17), one, "0.1...");
-    test_ceiling(dec64_new(22222222222222222, -17), one, "0.2...");
-    test_ceiling(dec64_new(33333333333333333, -17), one, "0.3...");
-    test_ceiling(dec64_new(4444444444444444, -16), one, "0.4...");
-    test_ceiling(dec64_new(5555555555555556, -16), one, "0.5...");
-    test_ceiling(dec64_new(6666666666666667, -16), one, "0.6...");
-    test_ceiling(dec64_new(7777777777777778, -16), one, "0.7...");
-    test_ceiling(dec64_new(8888888888888889, -16), one, "0.8...");
-    test_ceiling(dec64_new(10000000000000000, -16), one, "1");
+    test_ceiling(dec64_new(11111111111111111, -17), wun, "0.1...");
+    test_ceiling(dec64_new(22222222222222222, -17), wun, "0.2...");
+    test_ceiling(dec64_new(33333333333333333, -17), wun, "0.3...");
+    test_ceiling(dec64_new(4444444444444444, -16), wun, "0.4...");
+    test_ceiling(dec64_new(5555555555555556, -16), wun, "0.5...");
+    test_ceiling(dec64_new(6666666666666667, -16), wun, "0.6...");
+    test_ceiling(dec64_new(7777777777777778, -16), wun, "0.7...");
+    test_ceiling(dec64_new(8888888888888889, -16), wun, "0.8...");
+    test_ceiling(dec64_new(10000000000000000, -16), wun, "1");
     test_ceiling(dec64_new(-12500000000000000, -16), dec64_new(-1, 0), "-1.25");
     test_ceiling(dec64_new(-1500000000000000, -15), dec64_new(-1, 0), "-1.5");
     test_ceiling(dec64_new(-1560000000000000, -15), dec64_new(-1, 0), "-1.56");
@@ -487,15 +487,15 @@ static void test_all_ceiling() {
     test_ceiling(dec64_new(-6666666666666667, -16), zero, "-0.6...");
     test_ceiling(dec64_new(-7777777777777778, -16), zero, "-0.7...");
     test_ceiling(dec64_new(-8888888888888889, -16), zero, "-0.8...");
-    test_ceiling(dec64_new(-10000000000000000, -16), negative_one, "-10000000000000000e-16");
+    test_ceiling(dec64_new(-10000000000000000, -16), negative_wun, "-10000000000000000e-16");
     test_ceiling(dec64_new(449, -2), five, "4.49");
     test_ceiling(dec64_new(-449, -2), dec64_new(-4, 0), "-4.49");
     test_ceiling(dec64_new(450, -2), five, "4.50");
     test_ceiling(dec64_new(-450, -2), dec64_new(-4, 0), "-4.50");
-    test_ceiling(dec64_new(9, -1), one, "0.9");
+    test_ceiling(dec64_new(9, -1), wun, "0.9");
     test_ceiling(dec64_new(-9, -1), zero, "-0.9");
-    test_ceiling(almost_one, one, "almost_one");
-    test_ceiling(almost_negative_one, zero, "almost_negative_one");
+    test_ceiling(almost_wun, wun, "almost_wun");
+    test_ceiling(almost_negative_wun, zero, "almost_negative_wun");
     test_ceiling(dec64_new(-999999999999999, -15), zero, "-0.9...");
     test_ceiling(dec64_new(-9999999999999998, -16), zero, "-0.9...8");
 }
@@ -503,21 +503,21 @@ static void test_all_ceiling() {
 static void test_all_dec() {
     test_dec(nannan, nan, "nannan");
     test_dec(nan, nan, "nan");
-    test_dec(zero, negative_one, "zero");
-    test_dec(zip, negative_one, "zip");
-    test_dec(one, zero, "one");
+    test_dec(zero, negative_wun, "zero");
+    test_dec(zip, negative_wun, "zip");
+    test_dec(wun, zero, "wun");
     test_dec(half, dec64_new(-5, -1), "half");
     test_dec(cent, dec64_new(-99, -2), "cent");
-    test_dec(epsilon, almost_negative_one, "epsilon");
+    test_dec(epsilon, almost_negative_wun, "epsilon");
     test_dec(dec64_new(9999999999999999, 0), dec64_new(9999999999999998, 0), "9999999999999999");
     test_dec(dec64_new(10000000000000000, 0), dec64_new(9999999999999999, 0), "10000000000000000");
     test_dec(maxint_plus, maxint_plus, "maxint plus");
     test_dec(maxint, maxint - 256, "maxint");
-    test_dec(one_over_maxint, negative_one, "1/maxint");
+    test_dec(one_over_maxint, negative_wun, "1/maxint");
     test_dec(maxnum, maxnum, "maxnum");
     test_dec(googol, googol, "googol");
-    test_dec(almost_one, negative_epsilon, "almost_one");
-    test_dec(negative_maxint, dec64_new(-3602879701896397, 1), "negative_maxint"); 
+    test_dec(almost_wun, negative_epsilon, "almost_wun");
+    test_dec(negative_maxint, dec64_new(-3602879701896397, 1), "negative_maxint");
 
 }
 
@@ -526,7 +526,7 @@ static void test_all_divide() {
     test_divide(nan, nan, nan, "nan / nan");
     test_divide(nan, three, nan, "nan / 3");
     test_divide(nannan, nannan, nan, "nannan / nannan");
-    test_divide(nannan, one, nan, "nannan / 1");
+    test_divide(nannan, wun, nan, "nannan / 1");
     test_divide(zero, nan, zero, "0 / nan");
     test_divide(zero, nannan, zero, "0 / nannan");
     test_divide(zero, zip, zero, "zero / zip");
@@ -534,13 +534,13 @@ static void test_all_divide() {
     test_divide(zip, nannan, zero, "zip / nannan");
     test_divide(zip, zero, zero, "zip / zero");
     test_divide(zip, zip, zero, "zip / zip");
-    test_divide(zero, one, zero, "0 / 1");
+    test_divide(zero, wun, zero, "0 / 1");
     test_divide(zero, zero, zero, "0 / 0");
-    test_divide(one, zero, nan, "1 / 0");
-    test_divide(one, negative_one, dec64_new(-10000000000000000, -16), "1 / -1");
-    test_divide(negative_one, one, dec64_new(-10000000000000000, -16), "-1 / 1");
-    test_divide(one, two, dec64_new(5000000000000000, -16), "1 / 2");
-    test_divide(one, three, dec64_new(33333333333333333, -17), "1 / 3");
+    test_divide(wun, zero, nan, "1 / 0");
+    test_divide(wun, negative_wun, dec64_new(-10000000000000000, -16), "1 / -1");
+    test_divide(negative_wun, wun, dec64_new(-10000000000000000, -16), "-1 / 1");
+    test_divide(wun, two, dec64_new(5000000000000000, -16), "1 / 2");
+    test_divide(wun, three, dec64_new(33333333333333333, -17), "1 / 3");
     test_divide(two, three, dec64_new(6666666666666667, -16), "2 / 3");
     test_divide(two, dec64_new(30000000000000000, -16), dec64_new(6666666666666667, -16), "2 / 3 alias");
     test_divide(dec64_new(20000000000000000, -16), three, dec64_new(6666666666666667, -16), "2 / 3 alias");
@@ -552,7 +552,7 @@ static void test_all_divide() {
     test_divide(six, nan, nan, "6 / nan");
     test_divide(six, three, dec64_new(20000000000000000, -16), "6 / 3");
     test_divide(zero, nine, zero, "0 / 9");
-    test_divide(one, nine, dec64_new(11111111111111111, -17), "1 / 9");
+    test_divide(wun, nine, dec64_new(11111111111111111, -17), "1 / 9");
     test_divide(two, nine, dec64_new(22222222222222222, -17), "2 / 9");
     test_divide(three, nine, dec64_new(33333333333333333, -17), "3 / 9");
     test_divide(four, nine, dec64_new(4444444444444444, -16), "4 / 9");
@@ -560,9 +560,9 @@ static void test_all_divide() {
     test_divide(six, nine, dec64_new(6666666666666667, -16), "6 / 9");
     test_divide(seven, nine, dec64_new(7777777777777778, -16), "7 / 9");
     test_divide(eight, nine, dec64_new(8888888888888889, -16), "8 / 9");
-    test_divide(nine, nine, one, "9 / 9");
+    test_divide(nine, nine, wun, "9 / 9");
     test_divide(zero, negative_nine, zero, "0 / -9");
-    test_divide(one, negative_nine, dec64_new(-11111111111111111, -17), "1 / -9");
+    test_divide(wun, negative_nine, dec64_new(-11111111111111111, -17), "1 / -9");
     test_divide(two, negative_nine, dec64_new(-22222222222222222, -17), "2 / -9");
     test_divide(three, negative_nine, dec64_new(-33333333333333333, -17), "3 / -9");
     test_divide(four, negative_nine, dec64_new(-4444444444444444, -16), "4 / -9");
@@ -570,36 +570,36 @@ static void test_all_divide() {
     test_divide(six, negative_nine, dec64_new(-6666666666666667, -16), "6 / -9");
     test_divide(seven, negative_nine, dec64_new(-7777777777777778, -16), "7 / -9");
     test_divide(eight, negative_nine, dec64_new(-8888888888888889, -16), "8 / -9");
-    test_divide(nine, negative_nine, negative_one, "9 / -9");
+    test_divide(nine, negative_nine, negative_wun, "9 / -9");
     test_divide(pi, negative_pi, dec64_new(-10000000000000000, -16), "pi / -pi");
     test_divide(negative_pi, pi, dec64_new(-10000000000000000, -16), "-pi / pi");
     test_divide(negative_pi, negative_pi, dec64_new(10000000000000000, -16), "-pi / -pi");
     test_divide(dec64_new(-16, 0), ten, dec64_new(-16, -1), "-16 / 10");
     test_divide(maxint, epsilon, dec64_new(36028797018963967, 16), "maxint / epsilon");
-    test_divide(one, maxint, one_over_maxint, "one / maxint");
-    test_divide(one, one_over_maxint, maxint, "one / one / maxint");
-    test_divide(one, negative_maxint, dec64_new(-27755575615628914, -33), "one / -maxint");
+    test_divide(wun, maxint, one_over_maxint, "wun / maxint");
+    test_divide(wun, one_over_maxint, maxint, "wun / wun / maxint");
+    test_divide(wun, negative_maxint, dec64_new(-27755575615628914, -33), "wun / -maxint");
     test_divide(maxnum, epsilon, nan, "maxnum / epsilon");
     test_divide(maxnum, maxnum, dec64_new(10000000000000000, -16), "maxnum / maxnum");
-    test_divide(dec64_new(10, -1), maxint, one_over_maxint, "one / maxint alias 1");
-    test_divide(dec64_new(100, -2), maxint, one_over_maxint, "one / maxint alias 2");
-    test_divide(dec64_new(1000, -3), maxint, one_over_maxint, "one / maxint alias 3");
-    test_divide(dec64_new(10000, -4), maxint, one_over_maxint, "one / maxint alias 4");
-    test_divide(dec64_new(100000, -5), maxint, one_over_maxint, "one / maxint alias 5");
-    test_divide(dec64_new(1000000, -6), maxint, one_over_maxint, "one / maxint alias 6");
-    test_divide(dec64_new(10000000, -7), maxint, one_over_maxint, "one / maxint alias 7");
-    test_divide(dec64_new(100000000, -8), maxint, one_over_maxint, "one / maxint alias 8");
-    test_divide(dec64_new(1000000000, -9), maxint, one_over_maxint, "one / maxint alias 9");
-    test_divide(dec64_new(10000000000, -10), maxint, one_over_maxint, "one / maxint alias 10");
-    test_divide(dec64_new(100000000000, -11), maxint, one_over_maxint, "one / maxint alias 11");
-    test_divide(dec64_new(1000000000000, -12), maxint, one_over_maxint, "one / maxint alias 12");
-    test_divide(dec64_new(10000000000000, -13), maxint, one_over_maxint, "one / maxint alias 13");
-    test_divide(dec64_new(100000000000000, -14), maxint, one_over_maxint, "one / maxint alias 14");
-    test_divide(dec64_new(1000000000000000, -15), maxint, one_over_maxint, "one / maxint alias 15");
-    test_divide(dec64_new(10000000000000000, -16), maxint, one_over_maxint, "one / maxint alias 16");
+    test_divide(dec64_new(10, -1), maxint, one_over_maxint, "wun / maxint alias 1");
+    test_divide(dec64_new(100, -2), maxint, one_over_maxint, "wun / maxint alias 2");
+    test_divide(dec64_new(1000, -3), maxint, one_over_maxint, "wun / maxint alias 3");
+    test_divide(dec64_new(10000, -4), maxint, one_over_maxint, "wun / maxint alias 4");
+    test_divide(dec64_new(100000, -5), maxint, one_over_maxint, "wun / maxint alias 5");
+    test_divide(dec64_new(1000000, -6), maxint, one_over_maxint, "wun / maxint alias 6");
+    test_divide(dec64_new(10000000, -7), maxint, one_over_maxint, "wun / maxint alias 7");
+    test_divide(dec64_new(100000000, -8), maxint, one_over_maxint, "wun / maxint alias 8");
+    test_divide(dec64_new(1000000000, -9), maxint, one_over_maxint, "wun / maxint alias 9");
+    test_divide(dec64_new(10000000000, -10), maxint, one_over_maxint, "wun / maxint alias 10");
+    test_divide(dec64_new(100000000000, -11), maxint, one_over_maxint, "wun / maxint alias 11");
+    test_divide(dec64_new(1000000000000, -12), maxint, one_over_maxint, "wun / maxint alias 12");
+    test_divide(dec64_new(10000000000000, -13), maxint, one_over_maxint, "wun / maxint alias 13");
+    test_divide(dec64_new(100000000000000, -14), maxint, one_over_maxint, "wun / maxint alias 14");
+    test_divide(dec64_new(1000000000000000, -15), maxint, one_over_maxint, "wun / maxint alias 15");
+    test_divide(dec64_new(10000000000000000, -16), maxint, one_over_maxint, "wun / maxint alias 16");
     test_divide(minnum, two, minnum, "minnum / 2");
-    test_divide(one, 0x1437EEECD800000LL, dec64_new(28114572543455208, -31), "1/17!");
-    test_divide(one, 0x52D09F700003LL, dec64_new(28114572543455208, -31), "1/17!");
+    test_divide(wun, 0x1437EEECD800000LL, dec64_new(28114572543455208, -31), "1/17!");
+    test_divide(wun, 0x52D09F700003LL, dec64_new(28114572543455208, -31), "1/17!");
 }
 
 static void test_all_equal() {
@@ -608,21 +608,21 @@ static void test_all_equal() {
     test_equal(nan, nannan, false, "nan = nannan");
     test_equal(nannan, nannan, true, "nannan = nannan");
     test_equal(nannan, nan, false, "nannan = nan");
-    test_equal(nannan, one, false, "nannan = 1");
+    test_equal(nannan, wun, false, "nannan = 1");
     test_equal(zero, nan, false, "zero = nan");
     test_equal(zero, nannan, false, "0 = nannan");
     test_equal(zero, zip, true, "zero = zip");
     test_equal(zero, minnum, false, "zero = minnum");
-    test_equal(zero, one, false, "zero = one");
+    test_equal(zero, wun, false, "zero = wun");
     test_equal(zip, zero, true, "zip = zero");
     test_equal(zip, zip, true, "zip = zip");
-    test_equal(one, negative_one, false, "1 = -1");
+    test_equal(wun, negative_wun, false, "1 = -1");
     test_equal(two, two, true, "2 = 2");
     test_equal(two, dec64_new(2, -16), false, "2 = 2e-16");
     test_equal(pi, three, false, "pi = 3");
     test_equal(maxint, maxnum, false, "maxint = maxnum");
     test_equal(negative_maxint, maxint, false, "-maxint = maxint");
-    test_equal(negative_maxint, negative_one, false, "-maxint = -1");
+    test_equal(negative_maxint, negative_wun, false, "-maxint = -1");
     test_equal(0x1437EEECD800000LL, 0x52D09F700003LL, true, "17!");
 }
 
@@ -635,9 +635,9 @@ static void test_all_floor() {
     test_floor(epsilon, zero, "epsilon");
     test_floor(cent, zero, "cent");
     test_floor(half, zero, "half");
-    test_floor(one, one, "one");
-    test_floor(negative_one, negative_one, "negative_one");
-    test_floor(dec64_new(10000000000000001, -16), one, "1.0000000000000001");
+    test_floor(wun, wun, "wun");
+    test_floor(negative_wun, negative_wun, "negative_wun");
+    test_floor(dec64_new(10000000000000001, -16), wun, "1.0000000000000001");
     test_floor(dec64_new(-10000000000000001, -16), dec64_new(-2, 0), "-1.0000000000000001");
     test_floor(dec64_new(20000000000000000, -16), two, "two");
     test_floor(e, two, "e");
@@ -655,42 +655,42 @@ static void test_all_floor() {
     test_floor(dec64_new(7777777777777778, -16), zero, "0.7...");
     test_floor(dec64_new(8888888888888889, -16), zero, "0.8...");
     test_floor(dec64_new(9999999999999999, -16), zero, "0.9...");
-    test_floor(dec64_new(10000000000000000, -16), one, "1");
+    test_floor(dec64_new(10000000000000000, -16), wun, "1");
     test_floor(dec64_new(-12500000000000000, -16), dec64_new(-2, 0), "-1.25");
     test_floor(dec64_new(-1500000000000000, -15), dec64_new(-2, 0), "-1.5");
     test_floor(dec64_new(-1560000000000000, -15), dec64_new(-2, 0), "-1.56");
-    test_floor(dec64_new(-11111111111111111, -17), negative_one, "-0.1...");
-    test_floor(dec64_new(-22222222222222222, -17), negative_one, "-0.2...");
-    test_floor(dec64_new(-33333333333333333, -17), negative_one, "-0.3...");
-    test_floor(dec64_new(-4444444444444444, -16), negative_one, "-0.4...");
-    test_floor(dec64_new(-5555555555555556, -16), negative_one, "-0.5...");
-    test_floor(dec64_new(-6666666666666667, -16), negative_one, "-0.6...");
-    test_floor(dec64_new(-7777777777777778, -16), negative_one, "-0.7...");
-    test_floor(dec64_new(-8888888888888889, -16), negative_one, "-0.8...");
-    test_floor(dec64_new(-9999999999999999, -16), negative_one, "-0.9...");
-    test_floor(dec64_new(-10000000000000000, -16), negative_one, "-1.0...");
+    test_floor(dec64_new(-11111111111111111, -17), negative_wun, "-0.1...");
+    test_floor(dec64_new(-22222222222222222, -17), negative_wun, "-0.2...");
+    test_floor(dec64_new(-33333333333333333, -17), negative_wun, "-0.3...");
+    test_floor(dec64_new(-4444444444444444, -16), negative_wun, "-0.4...");
+    test_floor(dec64_new(-5555555555555556, -16), negative_wun, "-0.5...");
+    test_floor(dec64_new(-6666666666666667, -16), negative_wun, "-0.6...");
+    test_floor(dec64_new(-7777777777777778, -16), negative_wun, "-0.7...");
+    test_floor(dec64_new(-8888888888888889, -16), negative_wun, "-0.8...");
+    test_floor(dec64_new(-9999999999999999, -16), negative_wun, "-0.9...");
+    test_floor(dec64_new(-10000000000000000, -16), negative_wun, "-1.0...");
     test_floor(dec64_new(449, -2), four, "4.49");
     test_floor(dec64_new(-449, -2), dec64_new(-5, 0), "-4.49");
     test_floor(dec64_new(450, -2), four, "4.50");
     test_floor(dec64_new(-450, -2), dec64_new(-5, 0), "-4.50");
     test_floor(dec64_new(-400, -2), dec64_new(-4, 0), "-4.00");
-    test_floor(dec64_new(-400, -3), negative_one, "-0.400");
-    test_floor(dec64_new(-1, -127), negative_one, "-1e-127");
-    test_floor(dec64_new(-1, -13), negative_one, "-1e-13");
+    test_floor(dec64_new(-400, -3), negative_wun, "-0.400");
+    test_floor(dec64_new(-1, -127), negative_wun, "-1e-127");
+    test_floor(dec64_new(-1, -13), negative_wun, "-1e-13");
     test_floor(dec64_new(1, -12), zero, "1e-12");
-    test_floor(dec64_new(-1, -12), negative_one, "-1e-12");
-    test_floor(dec64_new(-1, -11), negative_one, "-1e-11");
-    test_floor(dec64_new(-11, -11), negative_one, "-11e-11");
-    test_floor(dec64_new(-111, -11), negative_one, "-111e-11");
-    test_floor(dec64_new(-22, -11), negative_one, "-22e-11");
-    test_floor(dec64_new(-1, -1), negative_one, "-1e-1");
-    test_floor(dec64_new(-10, -3), negative_one, "-10e-3");
+    test_floor(dec64_new(-1, -12), negative_wun, "-1e-12");
+    test_floor(dec64_new(-1, -11), negative_wun, "-1e-11");
+    test_floor(dec64_new(-11, -11), negative_wun, "-11e-11");
+    test_floor(dec64_new(-111, -11), negative_wun, "-111e-11");
+    test_floor(dec64_new(-22, -11), negative_wun, "-22e-11");
+    test_floor(dec64_new(-1, -1), negative_wun, "-1e-1");
+    test_floor(dec64_new(-10, -3), negative_wun, "-10e-3");
     test_floor(dec64_new(9, -1), zero, "0.9");
-    test_floor(dec64_new(-9, -1), negative_one, "-0.9");
-    test_floor(almost_one, zero, "almost_one");
-    test_floor(almost_negative_one, negative_one, "almost_negative_one");
-    test_floor(dec64_new(-999999999999999, -15), negative_one, "-0.9...");
-    test_floor(dec64_new(-9999999999999998, -16), negative_one, "-0.9...8");
+    test_floor(dec64_new(-9, -1), negative_wun, "-0.9");
+    test_floor(almost_wun, zero, "almost_wun");
+    test_floor(almost_negative_wun, negative_wun, "almost_negative_wun");
+    test_floor(dec64_new(-999999999999999, -15), negative_wun, "-0.9...");
+    test_floor(dec64_new(-9999999999999998, -16), negative_wun, "-0.9...8");
 }
 
 static void test_all_half() {
@@ -698,8 +698,8 @@ static void test_all_half() {
     test_half(nan, nan, "nan");
     test_half(zero, zero, "zero");
     test_half(zip, zero, "zip");
-    test_half(one, half, "one");
-    test_half(two, one, "two");
+    test_half(wun, half, "wun");
+    test_half(two, wun, "two");
     test_half(ten, five, "ten");
     test_half(minnum, minnum, "minnum");
     test_half(dec64_new(-2, 0), dec64_new(-1, 0), "-2");
@@ -709,16 +709,16 @@ static void test_all_half() {
 static void test_all_inc() {
     test_inc(nannan, nan, "nannan");
     test_inc(nan, nan, "nan");
-    test_inc(zero, one, "zero");
-    test_inc(one, two, "one");
+    test_inc(zero, wun, "zero");
+    test_inc(wun, two, "wun");
     test_inc(cent, dec64_new(101, -2), "cent");
     test_inc(epsilon, dec64_new(10000000000000001, -16), "epsilon");
     test_inc(dec64_new(9999999999999999, 0), dec64_new(10000000000000000, 0), "9999999999999999");
     test_inc(maxint, maxint_plus, "maxint");
-    test_inc(one_over_maxint, one, "1/maxint");
+    test_inc(one_over_maxint, wun, "1/maxint");
     test_inc(maxnum, maxnum, "maxnum");
     test_inc(googol, googol, "googol");
-    test_inc(almost_negative_one, epsilon, "almost_negative_one");
+    test_inc(almost_negative_wun, epsilon, "almost_negative_wun");
 }
 
 void test_all_int() {
@@ -728,10 +728,10 @@ void test_all_int() {
     test_int(zip, zero, "zip");
     test_int(epsilon, 0, "epsilon");
     test_int(ten, ten, "ten");
-    test_int(dec64_new(-10000000000000000, -16), negative_one, "-1");
-    test_int(one, one, "one");
-    test_floor(almost_one, zero, "almost_one");
-    test_floor(almost_negative_one, negative_one, "almost_negative_one");
+    test_int(dec64_new(-10000000000000000, -16), negative_wun, "-1");
+    test_int(wun, wun, "wun");
+    test_floor(almost_wun, zero, "almost_wun");
+    test_floor(almost_negative_wun, negative_wun, "almost_negative_wun");
     test_int(dec64_new(1, 1), dec64_new(10, 0), "10");
     test_int(dec64_new(1, 2), dec64_new(100, 0), "100");
     test_int(dec64_new(1, 3), dec64_new(1000, 0), "1000");
@@ -750,22 +750,22 @@ void test_all_int() {
     test_int(dec64_new(1, 16), dec64_new(10000000000000000, 0), "100000000000000000");
     test_int(dec64_new(1, 17), nan, "1000000000000000000");
     test_int(cent, 0, "cent");
-    test_int(dec64_new(10, -1), one, "one alias 1");
-    test_int(dec64_new(100, -2), one, "one alias 2");
-    test_int(dec64_new(1000, -3), one, "one alias 3");
-    test_int(dec64_new(10000, -4), one, "one alias 4");
-    test_int(dec64_new(100000, -5), one, "one alias 5");
-    test_int(dec64_new(1000000, -6), one, "one alias 6");
-    test_int(dec64_new(10000000, -7), one, "one alias 7");
-    test_int(dec64_new(100000000, -8), one, "one alias 8");
-    test_int(dec64_new(1000000000, -9), one, "one alias 9");
-    test_int(dec64_new(10000000000, -10), one, "one alias 10");
-    test_int(dec64_new(100000000000, -11), one, "one alias 11");
-    test_int(dec64_new(1000000000000, -12), one, "one alias 12");
-    test_int(dec64_new(10000000000000, -13), one, "one alias 13");
-    test_int(dec64_new(100000000000000, -14), one, "one alias 14");
-    test_int(dec64_new(1000000000000000, -15), one, "one alias 15");
-    test_int(dec64_new(10000000000000000, -16), one, "one alias 16");
+    test_int(dec64_new(10, -1), wun, "wun alias 1");
+    test_int(dec64_new(100, -2), wun, "wun alias 2");
+    test_int(dec64_new(1000, -3), wun, "wun alias 3");
+    test_int(dec64_new(10000, -4), wun, "wun alias 4");
+    test_int(dec64_new(100000, -5), wun, "wun alias 5");
+    test_int(dec64_new(1000000, -6), wun, "wun alias 6");
+    test_int(dec64_new(10000000, -7), wun, "wun alias 7");
+    test_int(dec64_new(100000000, -8), wun, "wun alias 8");
+    test_int(dec64_new(1000000000, -9), wun, "wun alias 9");
+    test_int(dec64_new(10000000000, -10), wun, "wun alias 10");
+    test_int(dec64_new(100000000000, -11), wun, "wun alias 11");
+    test_int(dec64_new(1000000000000, -12), wun, "wun alias 12");
+    test_int(dec64_new(10000000000000, -13), wun, "wun alias 13");
+    test_int(dec64_new(100000000000000, -14), wun, "wun alias 14");
+    test_int(dec64_new(1000000000000000, -15), wun, "wun alias 15");
+    test_int(dec64_new(10000000000000000, -16), wun, "wun alias 16");
     test_int(dec64_new(-12500000000000000, -16), dec64_new(-2, -0), "-1.25");
     test_int(maxint, maxint, "maxint");
     test_int(negative_maxint, negative_maxint, "negative_maxint");
@@ -779,7 +779,7 @@ static void test_all_integer_divide() {
     test_integer_divide(nan, three, nan, "nan / 3");
     test_integer_divide(six, nan, nan, "6 / nan");
     test_integer_divide(nan, nan, nan, "nan / nan");
-    test_integer_divide(nannan, one, nan, "nannan / 1");
+    test_integer_divide(nannan, wun, nan, "nannan / 1");
     test_integer_divide(zip, zero, zero, "zip / zero");
     test_integer_divide(zero, zip, zero, "zero / zip");
     test_integer_divide(zip, zip, zero, "zip / zip");
@@ -788,38 +788,38 @@ static void test_all_integer_divide() {
     test_integer_divide(zip, nan, zero, "zip / nan");
     test_integer_divide(zip, nannan, zero, "zip / nannan");
     test_integer_divide(nannan, nannan, nan, "nannan / nannan");
-    test_integer_divide(zero, one, zero, "0 / 1");
+    test_integer_divide(zero, wun, zero, "0 / 1");
     test_integer_divide(zero, zero, zero, "0 / 0");
-    test_integer_divide(one, one, one, "1 / 1");
-    test_integer_divide(one, zero, nan, "1 / 0");
-    test_integer_divide(one, negative_one, negative_one, "1 / -1");
-    test_integer_divide(negative_one, one, negative_one, "-1 / 1");
-    test_integer_divide(pi, negative_pi, negative_one, "pi / -pi");
-    test_integer_divide(negative_pi, pi, negative_one, "-pi / pi");
-    test_integer_divide(negative_pi, negative_pi, one, "-pi / -pi");
+    test_integer_divide(wun, wun, wun, "1 / 1");
+    test_integer_divide(wun, zero, nan, "1 / 0");
+    test_integer_divide(wun, negative_wun, negative_wun, "1 / -1");
+    test_integer_divide(negative_wun, wun, negative_wun, "-1 / 1");
+    test_integer_divide(pi, negative_pi, negative_wun, "pi / -pi");
+    test_integer_divide(negative_pi, pi, negative_wun, "-pi / pi");
+    test_integer_divide(negative_pi, negative_pi, wun, "-pi / -pi");
     test_integer_divide(six, three, two, "6 / 3");
-    test_integer_divide(maxnum, maxnum, one, "maxnum / maxnum");
-    test_integer_divide(one, two, zero, "1 / 2");
-    test_integer_divide(one, three, zero, "1 / 3");
+    test_integer_divide(maxnum, maxnum, wun, "maxnum / maxnum");
+    test_integer_divide(wun, two, zero, "1 / 2");
+    test_integer_divide(wun, three, zero, "1 / 3");
     test_integer_divide(two, three, zero, "2 / 3");
     test_integer_divide(two, dec64_new(30000000000000000, -16), zero, "2 / 3");
     test_integer_divide(dec64_new(20000000000000000, -16), three, zero, "2 / 3");
-    test_integer_divide(three, three, one, "3 / 3");
-    test_integer_divide(three, dec64_new(30000000000000000, -16), one, "3 / 3");
-    test_integer_divide(four, three, one, "4 / 3");
-    test_integer_divide(dec64_new(40000000000000000, -16), dec64_new(30000000000000000, -16), one, "4 / 3");
-    test_integer_divide(five, three, one, "5 / 3");
+    test_integer_divide(three, three, wun, "3 / 3");
+    test_integer_divide(three, dec64_new(30000000000000000, -16), wun, "3 / 3");
+    test_integer_divide(four, three, wun, "4 / 3");
+    test_integer_divide(dec64_new(40000000000000000, -16), dec64_new(30000000000000000, -16), wun, "4 / 3");
+    test_integer_divide(five, three, wun, "5 / 3");
     test_integer_divide(five, dec64_new(-3, 0), dec64_new(-2, 0), "5 / -3");
     test_integer_divide(five, dec64_new(-30000000000000000, -16), dec64_new(-2, 0), "5 / -3 alias");
     test_integer_divide(dec64_new(-5, 0), three, dec64_new(-2, 0), "-5 / 3");
-    test_integer_divide(dec64_new(-5, 0), dec64_new(-3, 0), one, "-5 / -3");
-    test_integer_divide(dec64_new(-5, 0), dec64_new(-30000000000000000, -16), one, "-5 / -3");
-    test_integer_divide(dec64_new(-50000000000000000, -16), dec64_new(-30000000000000000, -16), one, "-5 / -3");
+    test_integer_divide(dec64_new(-5, 0), dec64_new(-3, 0), wun, "-5 / -3");
+    test_integer_divide(dec64_new(-5, 0), dec64_new(-30000000000000000, -16), wun, "-5 / -3");
+    test_integer_divide(dec64_new(-50000000000000000, -16), dec64_new(-30000000000000000, -16), wun, "-5 / -3");
     test_integer_divide(dec64_new(-50000000000000000, -16), three, dec64_new(-2, 0), "-5 / 3");
     test_integer_divide(dec64_new(-16, 0), ten, dec64_new(-2, 0), "-16 / 10");
     test_integer_divide(maxnum, epsilon, nan, "maxnum / epsilon");
     test_integer_divide(maxint, epsilon, dec64_new(36028797018963967, 16), "maxint / epsilon");
-    test_integer_divide(dec64_new(10, -1), maxint, zero, "one / maxint");
+    test_integer_divide(dec64_new(10, -1), maxint, zero, "wun / maxint");
 }
 
 static void test_all_is_any_nan() {
@@ -827,7 +827,7 @@ static void test_all_is_any_nan() {
     test_is_any_nan(nannan, true, "nannan");
     test_is_any_nan(zero, false, "zero");
     test_is_any_nan(zip, false, "zip");
-    test_is_any_nan(one, false, "one");
+    test_is_any_nan(wun, false, "wun");
     test_is_any_nan(cent, false, "cent");
     test_is_any_nan(maxnum, false, "maxnum");
     test_is_any_nan(negative_maxnum, false, "-maxnum");
@@ -842,8 +842,8 @@ static void test_all_is_integer() {
     test_is_integer(epsilon, false, "epsilon");
     test_is_integer(cent, false, "cent");
     test_is_integer(half, false, "half");
-    test_is_integer(one, true, "one");
-    test_is_integer(negative_one, true, "negative_one");
+    test_is_integer(wun, true, "wun");
+    test_is_integer(negative_wun, true, "negative_wun");
     test_is_integer(dec64_new(10000000000000001, -16), false, "1.0000000000000001");
     test_is_integer(dec64_new(-10000000000000001, -16), false, "-1.0000000000000001");
     test_is_integer(dec64_new(20000000000000000, -16), true, "two");
@@ -894,8 +894,8 @@ static void test_all_is_integer() {
     test_is_integer(dec64_new(-10, -3), false, "-10e-3");
     test_is_integer(dec64_new(9, -1), false, "0.9");
     test_is_integer(dec64_new(-9, -1), false, "-0.9");
-    test_is_integer(almost_one, false, "almost_one");
-    test_is_integer(almost_negative_one, false, "almost_negative_one");
+    test_is_integer(almost_wun, false, "almost_wun");
+    test_is_integer(almost_negative_wun, false, "almost_negative_wun");
     test_is_integer(dec64_new(-999999999999999, -15), false, "-0.9...");
     test_is_integer(dec64_new(-9999999999999998, -16), false, "-0.9...8");
 }
@@ -905,7 +905,7 @@ static void test_all_is_zero() {
     test_is_zero(nannan, false, "nannan");
     test_is_zero(zero, true, "zero");
     test_is_zero(zip, true, "zip");
-    test_is_zero(one, false, "one");
+    test_is_zero(wun, false, "wun");
     test_is_zero(cent, false, "cent");
     test_is_zero(maxnum, false, "maxnum");
     test_is_zero(negative_maxnum, false, "-maxnum");
@@ -917,15 +917,15 @@ static void test_all_less() {
     test_less(nan, zero, nan, "nan < zero");
     test_less(nannan, nan, nan, "nannan < nan");
     test_less(nannan, nannan, nan, "nannan < nannan");
-    test_less(nannan, one, nan, "nannan < 1");
+    test_less(nannan, wun, nan, "nannan < 1");
     test_less(zero, nan, nan, "zero < nan");
     test_less(zero, nannan, nan, "0 < nannan");
     test_less(zero, zip, false, "zero < zip");
     test_less(zero, minnum, true, "zero < minnum");
-    test_less(zero, one, true, "zero < one");
+    test_less(zero, wun, true, "zero < wun");
     test_less(zip, zero, false, "zip < zero");
     test_less(zip, zip, false, "zip < zip");
-    test_less(one, negative_one, false, "1 < -1");
+    test_less(wun, negative_wun, false, "1 < -1");
     test_less(negative_nine, nine, true, "-9 < 9");
     test_less(two, two, false, "2 < 2");
     test_less(two, dec64_new(2, -16), false, "2 < 2e-16");
@@ -935,12 +935,12 @@ static void test_all_less() {
     test_less(maxint, maxnum, true, "maxint < maxnum");
     test_less(maxnum, maxint, false, "maxnum < maxint");
     test_less(negative_maxint, maxint, true, "-maxint < maxint");
-    test_less(negative_maxint, negative_one, true, "-maxint < -1");
+    test_less(negative_maxint, negative_wun, true, "-maxint < -1");
     test_less(maxnum, nan, nan, "maxnum < nan");
     test_less(nine, ten, true, "9 < 10");
     test_less(negative_nine, dec64_new(-1, 1), false, "-9 < -1E1");
-    test_less(almost_negative_one, negative_one, false, "-0.9... < -1");
-    test_less(almost_one, one, true, "0.9... < 1");
+    test_less(almost_negative_wun, negative_wun, false, "-0.9... < -1");
+    test_less(almost_wun, wun, true, "0.9... < 1");
     test_less(epsilon, minnum, false, "epsilon < minnum");
     test_less(e, two, false, "e < 2");
     test_less(e, three, true, "e < 3");
@@ -957,25 +957,25 @@ static void test_all_modulo() {
     test_modulo(nan, nan, nan, "nan % nan");
     test_modulo(nan, three, nan, "nan % 3");
     test_modulo(nannan, nannan, nan, "nannan % nannan");
-    test_modulo(nannan, one, nan, "nannan % 1");
+    test_modulo(nannan, wun, nan, "nannan % 1");
     test_modulo(zero, nan, zero, "0 % nan");
     test_modulo(zero, nannan, zero, "0 % nannan");
     test_modulo(zero, zero, zero, "0 % 0");
     test_modulo(zero, zip, zero, "zero % zip");
-    test_modulo(zero, one, zero, "0 % 1");
+    test_modulo(zero, wun, zero, "0 % 1");
     test_modulo(zero, maxnum, zero, "0 % maxnum");
     test_modulo(zip, nan, zero, "zip % nan");
     test_modulo(zip, nannan, zero, "zip % nannan");
     test_modulo(zip, zero, zero, "zip % zero");
     test_modulo(zip, zip, zero, "zip % zip");
-    test_modulo(one, negative_one, zero, "1 % -1");
-    test_modulo(one, zero, nan, "1 % 0");
-    test_modulo(one, one, zero, "1 % 1");
-    test_modulo(one, two, one, "1 % 2");
-    test_modulo(one, three, one, "1 % 3");
-    test_modulo(one, maxint, one, "one % maxint");
-    test_modulo(dec64_new(10, -1), maxint, dec64_new(10, -1), "one % maxint");
-    test_modulo(negative_one, one, zero, "-1 % 1");
+    test_modulo(wun, negative_wun, zero, "1 % -1");
+    test_modulo(wun, zero, nan, "1 % 0");
+    test_modulo(wun, wun, zero, "1 % 1");
+    test_modulo(wun, two, wun, "1 % 2");
+    test_modulo(wun, three, wun, "1 % 3");
+    test_modulo(wun, maxint, wun, "wun % maxint");
+    test_modulo(dec64_new(10, -1), maxint, dec64_new(10, -1), "wun % maxint");
+    test_modulo(negative_wun, wun, zero, "-1 % 1");
     test_modulo(two, three, two, "2 % 3");
     test_modulo(dec64_new(20000000000000000, -16), three, two, "2 % 3");
     test_modulo(two, dec64_new(30000000000000000, -16), two, "2 % 3 alias");
@@ -985,16 +985,16 @@ static void test_all_modulo() {
     test_modulo(pi, negative_pi, zero, "pi % -pi");
     test_modulo(negative_pi, pi, zero, "-pi % pi");
     test_modulo(negative_pi, negative_pi, zero, "-pi % -pi");
-    test_modulo(four, three, one, "4 % 3");
-    test_modulo(dec64_new(40000000000000000, -16), dec64_new(3000000000000000, -15), one, "4 % 3");
-    test_modulo(dec64_new(40000000000000000, -16), dec64_new(30000000000000000, -16), one, "4 % 3");
+    test_modulo(four, three, wun, "4 % 3");
+    test_modulo(dec64_new(40000000000000000, -16), dec64_new(3000000000000000, -15), wun, "4 % 3");
+    test_modulo(dec64_new(40000000000000000, -16), dec64_new(30000000000000000, -16), wun, "4 % 3");
     test_modulo(five, three, two, "5 % 3");
-    test_modulo(five, dec64_new(-30000000000000000, -16), negative_one, "5 % -3 alias");
+    test_modulo(five, dec64_new(-30000000000000000, -16), negative_wun, "5 % -3 alias");
     test_modulo(five, dec64_new(-3, 0), dec64_new(-1, 0), "5 % -3");
-    test_modulo(dec64_new(-5, 0), three, one, "-5 % 3");
+    test_modulo(dec64_new(-5, 0), three, wun, "-5 % 3");
     test_modulo(dec64_new(-5, 0), dec64_new(-3, 0), dec64_new(-2, 0), "-5 % -3");
     test_modulo(dec64_new(-5, 0), dec64_new(-30000000000000000, -16), dec64_new(-2, 0), "-5 % -3");
-    test_modulo(dec64_new(-50000000000000000, -16), three, one, "-5 % 3");
+    test_modulo(dec64_new(-50000000000000000, -16), three, wun, "-5 % 3");
     test_modulo(dec64_new(-50000000000000000, -16), dec64_new(-30000000000000000, -16), dec64_new(-2, 0), "-5 % -3");
     test_modulo(six, nan, nan, "6 % nan");
     test_modulo(six, three, zero, "6 % 3");
@@ -1007,7 +1007,7 @@ static void test_all_multiply() {
     test_multiply(nan, nan, nan, "nan * nan");
     test_multiply(nan, zero, zero, "nan * zero");
     test_multiply(nannan, nannan, nan, "nannan * nannan");
-    test_multiply(nannan, one, nan, "nannan * 1");
+    test_multiply(nannan, wun, nan, "nannan * 1");
     test_multiply(zero, nan, zero, "0 * nan");
     test_multiply(zero, nannan, zero, "0 * nannan");
     test_multiply(zero, zip, zero, "zero * zip");
@@ -1017,14 +1017,14 @@ static void test_all_multiply() {
     test_multiply(minnum, half, minnum, "minnum * half");
     test_multiply(minnum, minnum, zero, "minnum * minnum");
     test_multiply(epsilon, epsilon, dec64_new(1, -32), "epsilon * epsilon");
-    test_multiply(one, nannan, nan, "1 * nannan");
-    test_multiply(negative_one, one, negative_one, "-1 * 1");
-    test_multiply(negative_one, negative_one, one, "-1 * -1");
+    test_multiply(wun, nannan, nan, "1 * nannan");
+    test_multiply(negative_wun, wun, negative_wun, "-1 * 1");
+    test_multiply(negative_wun, negative_wun, wun, "-1 * -1");
     test_multiply(two, five, ten, "2 * 5");
     test_multiply(two, maxnum, nan, "2 * maxnum");
-    test_multiply(two, dec64_new(36028797018963967, 126), dec64_new(7205759403792793, 127), "2 * a big one");
+    test_multiply(two, dec64_new(36028797018963967, 126), dec64_new(7205759403792793, 127), "2 * a big wun");
     test_multiply(three, two, six, "3 * 2");
-    test_multiply(ten, dec64_new(36028797018963967, 126), maxnum, "10 * a big one");
+    test_multiply(ten, dec64_new(36028797018963967, 126), maxnum, "10 * a big wun");
     test_multiply(ten, dec64_new(1, 127), dec64_new(10, 127), "10 * 1e127");
     test_multiply(dec64_new(1, 2), dec64_new(1, 127), dec64_new(100, 127), "1e2 * 1e127");
     test_multiply(dec64_new(1, 12), dec64_new(1, 127), dec64_new(1000000000000, 127), "1e2 * 1e127");
@@ -1037,7 +1037,7 @@ static void test_all_multiply() {
     test_multiply(maxint, zero, zero, "maxint * zero");
     test_multiply(maxint, epsilon, dec64_new(36028797018963967, -16), "maxint * epsilon");
     test_multiply(maxint, maxint, dec64_new(12980742146337068, 17), "maxint * maxint");
-    test_multiply(maxint, one_over_maxint, one, "maxint * 1 / maxint");
+    test_multiply(maxint, one_over_maxint, wun, "maxint * 1 / maxint");
     test_multiply(negative_maxint, nan, nan, "-maxint * nan");
     test_multiply(negative_maxint, maxint, dec64_new(-12980742146337069, 17), "-maxint * maxint");
     test_multiply(maxnum, maxnum, nan, "maxnum * maxnum");
@@ -1050,8 +1050,8 @@ static void test_all_neg() {
     test_neg(100, zero, "zero alias");
     test_neg(zero, zero, "zero");
     test_neg(zip, zero, "zip");
-    test_neg(one, negative_one, "one");
-    test_neg(negative_one, one, "-1");
+    test_neg(wun, negative_wun, "wun");
+    test_neg(negative_wun, wun, "-1");
     test_neg(maxint, dec64_new(-36028797018963967, 0), "maxint");
     test_neg(negative_maxint, maxint_plus, "-maxint");
     test_neg(maxnum, dec64_new(-36028797018963967, 127), "maxnum");
@@ -1062,7 +1062,7 @@ static void test_all_new() {
     test_new(0, 0, zero, "zero");
     test_new(0, 1000, zero, "0e1000");
     test_new(0, -1000, zero, "0e-1000");
-    test_new(1, 0, (1 << 8), "one");
+    test_new(1, 0, (1 << 8), "wun");
     test_new(1, 1000, nan, "0e1000");
     test_new(1, -1000, zero, "0e-1000");
     test_new(-1, 127, (-1 << 8) + 127, "-1e127");
@@ -1159,8 +1159,8 @@ void test_all_normal() {
     test_normal(zip, zero, "zip");
     test_normal(epsilon, epsilon, "epsilon");
     test_normal(ten, ten, "ten");
-    test_normal(dec64_new(-10000000000000000, -16), negative_one, "-1");
-    test_normal(one, one, "one");
+    test_normal(dec64_new(-10000000000000000, -16), negative_wun, "-1");
+    test_normal(wun, wun, "wun");
     test_normal(dec64_new(1, 1), dec64_new(10, 0), "10");
     test_normal(dec64_new(1, 2), dec64_new(100, 0), "100");
     test_normal(dec64_new(1, 3), dec64_new(1000, 0), "1000");
@@ -1180,22 +1180,22 @@ void test_all_normal() {
     test_normal(dec64_new(1, 17), dec64_new(100000000000000000, 0), "1000000000000000000");
     test_normal(cent, cent, "cent");
     test_normal(pi, pi, "pi");
-    test_normal(dec64_new(10, -1), one, "one alias 1");
-    test_normal(dec64_new(100, -2), one, "one alias 2");
-    test_normal(dec64_new(1000, -3), one, "one alias 3");
-    test_normal(dec64_new(10000, -4), one, "one alias 4");
-    test_normal(dec64_new(100000, -5), one, "one alias 5");
-    test_normal(dec64_new(1000000, -6), one, "one alias 6");
-    test_normal(dec64_new(10000000, -7), one, "one alias 7");
-    test_normal(dec64_new(100000000, -8), one, "one alias 8");
-    test_normal(dec64_new(1000000000, -9), one, "one alias 9");
-    test_normal(dec64_new(10000000000, -10), one, "one alias 10");
-    test_normal(dec64_new(100000000000, -11), one, "one alias 11");
-    test_normal(dec64_new(1000000000000, -12), one, "one alias 12");
-    test_normal(dec64_new(10000000000000, -13), one, "one alias 13");
-    test_normal(dec64_new(100000000000000, -14), one, "one alias 14");
-    test_normal(dec64_new(1000000000000000, -15), one, "one alias 15");
-    test_normal(dec64_new(10000000000000000, -16), one, "one alias 16");
+    test_normal(dec64_new(10, -1), wun, "wun alias 1");
+    test_normal(dec64_new(100, -2), wun, "wun alias 2");
+    test_normal(dec64_new(1000, -3), wun, "wun alias 3");
+    test_normal(dec64_new(10000, -4), wun, "wun alias 4");
+    test_normal(dec64_new(100000, -5), wun, "wun alias 5");
+    test_normal(dec64_new(1000000, -6), wun, "wun alias 6");
+    test_normal(dec64_new(10000000, -7), wun, "wun alias 7");
+    test_normal(dec64_new(100000000, -8), wun, "wun alias 8");
+    test_normal(dec64_new(1000000000, -9), wun, "wun alias 9");
+    test_normal(dec64_new(10000000000, -10), wun, "wun alias 10");
+    test_normal(dec64_new(100000000000, -11), wun, "wun alias 11");
+    test_normal(dec64_new(1000000000000, -12), wun, "wun alias 12");
+    test_normal(dec64_new(10000000000000, -13), wun, "wun alias 13");
+    test_normal(dec64_new(100000000000000, -14), wun, "wun alias 14");
+    test_normal(dec64_new(1000000000000000, -15), wun, "wun alias 15");
+    test_normal(dec64_new(10000000000000000, -16), wun, "wun alias 16");
     test_normal(dec64_new(-12500000000000000, -16), dec64_new(-125, -2), "-1.25");
 }
 
@@ -1204,11 +1204,11 @@ static void test_all_not() {
     test_not(true, false, "true");
     test_not(nan, nan, "nan");
     test_not(nannan, nan, "nannan");
-    test_not(zip, one, "zip");
+    test_not(zip, wun, "zip");
     test_not(dec64_new(10, -1), zero, "true alias");
-    test_not(almost_one, nan, "almost 1");
+    test_not(almost_wun, nan, "almost 1");
     test_not(two, nan, "2");
-    test_not(negative_one, nan, "-1");
+    test_not(negative_wun, nan, "-1");
     test_not(negative_maxint, nan, "-maxint");
     test_not(negative_maxnum, nan, "-maxnum");
 }
@@ -1238,7 +1238,7 @@ static void test_all_round() {
     test_round(pi, dec64_new(-4, 0), dec64_new(31416, -4), "pi -4");
     test_round(pi, dec64_new(-3, 0), dec64_new(3142, -3), "pi -3");
     test_round(pi, dec64_new(-2, 0), dec64_new(314, -2), "pi -2");
-    test_round(pi, negative_one, dec64_new(31, -1), "pi -1");
+    test_round(pi, negative_wun, dec64_new(31, -1), "pi -1");
     test_round(pi, zero, three, "pi 0");
     test_round(negative_pi, dec64_new(-18, 0), negative_pi, "-pi -18");
     test_round(negative_pi, dec64_new(-17, 0), negative_pi, "-pi -17");
@@ -1257,19 +1257,19 @@ static void test_all_round() {
     test_round(negative_pi, dec64_new(-4, 0), dec64_new(-31416, -4), "-pi -4");
     test_round(negative_pi, dec64_new(-3, 0), dec64_new(-3142, -3), "-pi -3");
     test_round(negative_pi, dec64_new(-2, 0), dec64_new(-314, -2), "-pi -2");
-    test_round(negative_pi, negative_one, dec64_new(-31, -1), "-pi -1");
+    test_round(negative_pi, negative_wun, dec64_new(-31, -1), "-pi -1");
     test_round(negative_pi, zero, dec64_new(-3, 0), "-pi 0");
     test_round(dec64_new(449, -2), dec64_new(-2, 0), dec64_new(449, -2), "4.49 -2");
-    test_round(dec64_new(449, -2), negative_one, dec64_new(45, -1), "4.49 -1");
+    test_round(dec64_new(449, -2), negative_wun, dec64_new(45, -1), "4.49 -1");
     test_round(dec64_new(449, -2), zero, four, "4.49 0");
     test_round(dec64_new(450, -2), zero, five, "4.50 0");
     test_round(dec64_new(-449, -2), dec64_new(-2, 0), dec64_new(-449, -2), "-4.49 -2");
-    test_round(dec64_new(-449, -2), negative_one, dec64_new(-45, -1), "-4.49 -1");
+    test_round(dec64_new(-449, -2), negative_wun, dec64_new(-45, -1), "-4.49 -1");
     test_round(dec64_new(-449, -2), zero, dec64_new(-4, 0), "-4.49 0");
     test_round(dec64_new(-450, -2), zero, dec64_new(-5, 0), "-4.50 0");
-    test_round(maxint, negative_one, maxint, "maxint -1");
+    test_round(maxint, negative_wun, maxint, "maxint -1");
     test_round(maxint, zero, maxint, "maxint 0");
-    test_round(maxint, one, dec64_new(3602879701896397, 1), "maxint 1");
+    test_round(maxint, wun, dec64_new(3602879701896397, 1), "maxint 1");
     test_round(maxint, two, dec64_new(3602879701896400, 1), "maxint 2");
     test_round(maxint, three, dec64_new(3602879701896400, 1), "maxint 3");
     test_round(maxint, four, dec64_new(36028797018960000, 0), "maxint 4");
@@ -1287,8 +1287,8 @@ static void test_all_round() {
     test_round(maxint, dec64_new(16, 0), dec64_new(40000000000000000, 0), "maxint 16");
     test_round(maxint, dec64_new(17, 0), zero, "maxint 17");
     test_round(dec64_new(34999999999999999, 0), zero, dec64_new(34999999999999999, 0), "34999999999999999 0");
-    test_round(dec64_new(34999999999999995, 0), one, dec64_new(35000000000000000, 0), "34999999999999995 1");
-    test_round(dec64_new(34999999999999994, 0), one, dec64_new(34999999999999990, 0), "34999999999999994 1");
+    test_round(dec64_new(34999999999999995, 0), wun, dec64_new(35000000000000000, 0), "34999999999999995 1");
+    test_round(dec64_new(34999999999999994, 0), wun, dec64_new(34999999999999990, 0), "34999999999999994 1");
     test_round(dec64_new(34999999999999950, 0), two, dec64_new(35000000000000000, 0), "34999999999999950 2");
     test_round(dec64_new(34999999999999949, 0), two, dec64_new(34999999999999900, 0), "34999999999999949 2");
     test_round(dec64_new(34999999999999500, 0), three, dec64_new(35000000000000000, 0), "34999999999999500 3");
@@ -1340,27 +1340,27 @@ static void test_all_signum() {
     test_signum(zero, zero, "zero");
     test_signum(zip, zero, "zip");
     test_signum(dec64_new(0, -16), zero, "zero");
-    test_signum(minnum, one, "minnum");
-    test_signum(epsilon, one, "epsilon");
-    test_signum(cent, one, "cent");
-    test_signum(half, one, "half");
-    test_signum(one, one, "one");
-    test_signum(negative_one, negative_one, "negative_one");
-    test_signum(dec64_new(-12500000000000000, -16), negative_one, "-1.25");
-    test_signum(dec64_new(-1500000000000000, -15), negative_one, "-1.5");
-    test_signum(dec64_new(-1560000000000000, -15), negative_one, "-1.56");
-    test_signum(dec64_new(20000000000000000, -16), one, "two");
-    test_signum(e, one, "e");
-    test_signum(pi, one, "pi");
-    test_signum(negative_maxint, negative_one, "negative_maxint");
-    test_signum(maxint, one, "maxint");
-    test_signum(maxnum, one, "maxnum");
+    test_signum(minnum, wun, "minnum");
+    test_signum(epsilon, wun, "epsilon");
+    test_signum(cent, wun, "cent");
+    test_signum(half, wun, "half");
+    test_signum(wun, wun, "wun");
+    test_signum(negative_wun, negative_wun, "negative_wun");
+    test_signum(dec64_new(-12500000000000000, -16), negative_wun, "-1.25");
+    test_signum(dec64_new(-1500000000000000, -15), negative_wun, "-1.5");
+    test_signum(dec64_new(-1560000000000000, -15), negative_wun, "-1.56");
+    test_signum(dec64_new(20000000000000000, -16), wun, "two");
+    test_signum(e, wun, "e");
+    test_signum(pi, wun, "pi");
+    test_signum(negative_maxint, negative_wun, "negative_maxint");
+    test_signum(maxint, wun, "maxint");
+    test_signum(maxnum, wun, "maxnum");
 }
 
 static void test_all_subtract() {
     test_subtract(nan, three, nan, "nan - 3");
     test_subtract(nannan, nannan, nan, "nannan - nannan");
-    test_subtract(nannan, one, nan, "nannan - 1");
+    test_subtract(nannan, wun, nan, "nannan - 1");
     test_subtract(zero, nannan, nan, "0 - nannan");
     test_subtract(zero, zip, zero, "zero - zip");
     test_subtract(zero, negative_pi, pi, "0 - -pi");
@@ -1370,10 +1370,10 @@ static void test_all_subtract() {
     test_subtract(zip, zero, zero, "zip - zero");
     test_subtract(zip, zip, zero, "zip - zip");
     test_subtract(epsilon, epsilon, zero, "epsilon - epsilon");
-    test_subtract(one, negative_maxint, maxint_plus, "1  - -maxint");
-    test_subtract(one, epsilon, almost_one, "1 - epsilon");
-    test_subtract(one, almost_one, epsilon, "1 - almost_one");
-    test_subtract(negative_one, negative_maxint, maxint, "-1  - -maxint");
+    test_subtract(wun, negative_maxint, maxint_plus, "1  - -maxint");
+    test_subtract(wun, epsilon, almost_wun, "1 - epsilon");
+    test_subtract(wun, almost_wun, epsilon, "1 - almost_wun");
+    test_subtract(negative_wun, negative_maxint, maxint, "-1  - -maxint");
     test_subtract(three, nan, nan, "3 - nan");
     test_subtract(three, dec64_new(30000000000000000, -16), zero, "equal but with different exponents");
     test_subtract(three, four, dec64_new(-1, 0), "3 - 4");
@@ -1387,7 +1387,7 @@ static void test_all_subtract() {
     test_subtract(maxnum, maxint, maxnum, "maxnum - maxint");
     test_subtract(maxnum, negative_maxint, maxnum, "maxnum - -maxint");
     test_subtract(maxnum, maxnum, zero, "maxnum - maxnum");
-    test_subtract(almost_negative_one, almost_negative_one, zero, "almost_negative_one - almost_negative_one");
+    test_subtract(almost_negative_wun, almost_negative_wun, zero, "almost_negative_wun - almost_negative_wun");
 }
 
 static int do_tests(int level_of_detail) {


### PR DESCRIPTION
This makes Dec64 the first standard to officially recognize the [new spelling of 1](https://github.com/douglascrockford/fulfill/pull/1#issuecomment-415508178).

This commit contains no known breaking changes, and maintains the old spelling in documentation. I thought it best to leave that for a future change.