### PR TITLE
Update dec64.asm.html

### DIFF
--- a/dec64.asm.html
+++ b/dec64.asm.html
@@ -351,7 +351,7 @@ a <var>coefficient</var> and an <var>exponent</var>.</p>
 dec64</h3>
 <p>Compare two  numbers. If either is <var>nan</var>, return
     <code>DEC64_NAN</code>. If they are exactly equal, return
-    <code>DEC64_FALSE</code>, otherwise return <code>DEC64_FALSE</code>. Denormal
+    <code>DEC64_TRUE</code>, otherwise return <code>DEC64_FALSE</code>. Denormal
     zeros are equal but denormal nans are not.</p>
 <h3 id="dec64_is_false">dec64_is_false(<var>boolean</var>: dec64) returns
 <var>comparison</var>: dec64</h3>


### PR DESCRIPTION
There was apparently a small error saying that `dec64_is_equal` would either return `DEC64_NAN` or `DEC64_FALSE` and never `DEC64_TRUE`, which first makes no sense, and second isn't true when looking at `dec64.asm` lines 1285-1294.