### PR TITLE
dec64_round

### DIFF
--- a/dec64.asm
+++ b/dec64.asm
@@ -441,6 +441,10 @@ dec64_round: function_with_two_parameters
 
 ; The place should be between -16 and 16.
 
+    pad
+
+round_begin:
+
     cmp     r1_b, 128               ; is the number nan?
     jz      return_null
     test    r2_b, r2_b              ; is places already an integer?
@@ -492,7 +496,7 @@ round_places:
     cmp     r2_b, 128
     jne     round_normal
     xor     r2, r2
-    jmp     dec64_round
+    jmp     round_begin
     pad
 
 round_normal:
@@ -504,7 +508,7 @@ round_normal:
     jnz     return_null
     mov     r1, r10
     mov     r2, r0
-    jmp     dec64_round
+    jmp     round_begin
 
     pad; -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 

--- a/dec64_math.c
+++ b/dec64_math.c
@@ -143,7 +143,7 @@ dec64 dec64_asin(dec64 slope) {
         dec64_is_nan(slope) == DEC64_TRUE ||
         dec64_is_less(DEC64_ONE, dec64_abs(slope)) == DEC64_TRUE
     ) {
-        return DEC64_NAN;
+        return DEC64_NULL;
     }
     dec64 bottom = D_2;
     dec64 factor = slope;
@@ -182,7 +182,7 @@ dec64 dec64_atan(dec64 slope) {
 dec64 dec64_atan2(dec64 y, dec64 x) {
     if (dec64_is_zero(x) == DEC64_TRUE) {
         if (dec64_is_zero(y) == DEC64_TRUE) {
-            return DEC64_NAN;
+            return DEC64_NULL;
         } else if (y < 0) {
             return D_NHALF_PI;
         } else {
@@ -237,7 +237,7 @@ dec64 dec64_raise(dec64 coefficient, dec64 exponent) {
         exponent = dec64_neg(exponent);
     }
     if (dec64_is_nan(coefficient) == DEC64_TRUE) {
-        return DEC64_NAN;
+        return DEC64_NULL;
     }
     if (dec64_is_zero(coefficient) == DEC64_TRUE) {
         return 0;
@@ -277,12 +277,12 @@ dec64 dec64_factorial(dec64 x) {
     if (c >= 0 && c < FAC && dec64_exponent(n) == 0) {
         return factorials[c];
     }
-    return DEC64_NAN;
+    return DEC64_NULL;
 }
 
 dec64 dec64_log(dec64 x) {
     if (x <= 0 || dec64_is_nan(x) == DEC64_TRUE) {
-        return DEC64_NAN;
+        return DEC64_NULL;
     }
     if (dec64_is_equal(x, DEC64_ONE) == DEC64_TRUE) {
         return DEC64_ZERO;
@@ -304,7 +304,7 @@ dec64 dec64_log(dec64 x) {
             result,
             dec64_divide(factor, divisor)
         );
-        if (result == progress || progress == DEC64_NAN) {
+        if (result == progress || progress == DEC64_NULL) {
             break;
         }
         result = progress;
@@ -357,7 +357,7 @@ dec64 dec64_root(dec64 index, dec64 radicand) {
             && (dec64_coefficient(index) & 1) == 0
         )
     ) {
-        return DEC64_NAN;
+        return DEC64_NULL;
     }
     if (dec64_is_zero(radicand) == DEC64_TRUE) {
         return DEC64_ZERO;
@@ -370,7 +370,7 @@ dec64 dec64_root(dec64 index, dec64 radicand) {
     }
     dec64 index_minus_one = dec64_add(DEC64_NEGATIVE_ONE, index);
     result = DEC64_ONE;
-    dec64 prosult = DEC64_NAN;
+    dec64 prosult = DEC64_NULL;
     while (1) {
         dec64 progress = dec64_divide(
             dec64_add(
@@ -478,7 +478,7 @@ dec64 dec64_sqrt(dec64 radicand) {
         }
         return result;
     } else {
-        return DEC64_NAN;
+        return DEC64_NULL;
     }
 }
 

--- a/dec64_math_test.c
+++ b/dec64_math_test.c
@@ -58,7 +58,7 @@ static dec64 negative_maxnum;
 static dec64 negative_pi;
 
 static void define_constants() {
-    nan = DEC64_NAN;                /* not a number */
+    nan = DEC64_NULL;               /* not a number */
     nannan = 32896;                 /* a non-normal nan */
     zero = DEC64_ZERO;              /* 0 */
     zip = 1;                        /* a non normal 0 */

--- a/dec64_string.c
+++ b/dec64_string.c
@@ -68,7 +68,7 @@ static void digitize(dec64_string_state state) {
     }
 }
 
-static emit(dec64_string_state state, int c) {
+static void emit(dec64_string_state state, int c) {
     if (state->string != NULL) {
         if (c > 0) {
             state->string[state->length] = (dec64_string_char)c;
@@ -236,7 +236,7 @@ dec64_string_state dec64_string_begin() {
         state->mode = standard_mode;
         state->nr_digits = 0;
         state->nr_zeros = 0;
-        state->number = DEC64_NAN;
+        state->number = DEC64_NULL;
         state->places = 0;
         state->separation = 3;
         state->separator = 0;
@@ -358,7 +358,7 @@ void dec64_string_separator(
 dec64 dec64_from_string(dec64_string_state state, dec64_string_char string[]) {
 /*
     Convert a string into a dec64. If conversion is not possible for any
-    reason, the result will be DEC64_NAN.
+    reason, the result will be DEC64_NULL.
 */
     int at;
     int c;
@@ -374,7 +374,7 @@ dec64 dec64_from_string(dec64_string_state state, dec64_string_char string[]) {
     int64 sign_exp;
 
     if (state == NULL || state->valid != confirmed || string == NULL) {
-        return DEC64_NAN;
+        return DEC64_NULL;
     }
 /*
     Get the first character.
@@ -461,11 +461,11 @@ dec64 dec64_from_string(dec64_string_state state, dec64_string_char string[]) {
                 }
 /*
     There is a decimal point. If there is more than one decimal point,
-    return DEC64_NAN.
+    return DEC64_NULL.
 */
             } else if (c == state->decimal_point) {
                 if (point) {
-                    return DEC64_NAN;
+                    return DEC64_NULL;
                 }
                 point = 1;
 /*
@@ -498,10 +498,10 @@ dec64 dec64_from_string(dec64_string_state state, dec64_string_char string[]) {
                                 ok = 1;
                                 exp = exp * 10 + (c - '0');
                                 if (exp < 0) {
-                                    return DEC64_NAN;
+                                    return DEC64_NULL;
                                 }
                             } else {
-                                return DEC64_NAN;
+                                return DEC64_NULL;
                             }
                             at += 1;
                             c = string[at];
@@ -517,10 +517,10 @@ dec64 dec64_from_string(dec64_string_state state, dec64_string_char string[]) {
                         );
                     }
 /*
-    If any other character is seen, return DEC64_NAN.
+    If any other character is seen, return DEC64_NULL.
 */
                 }
-                return DEC64_NAN;
+                return DEC64_NULL;
             }
         }
 /*
@@ -535,7 +535,7 @@ dec64 dec64_from_string(dec64_string_state state, dec64_string_char string[]) {
     return (
         ok
         ? dec64_new(sign * coefficient, exponent)
-        : DEC64_NAN
+        : DEC64_NULL
     );
 }
 

--- a/dec64_string.html
+++ b/dec64_string.html
@@ -324,7 +324,7 @@ dec64_from_string(state, &quot;1,024.0000&quot;)</pre></td>
     <td><pre>1024</pre></td>
   </tr>
   <tr>
-    <td><pre>dec64_string_end();</pre></td>
+    <td><pre>dec64_string_end(state);</pre></td>
     <td><pre>&nbsp;</pre></td>
   </tr>
 </table>

--- a/dec64_string.html
+++ b/dec64_string.html
@@ -261,7 +261,7 @@ th {
 )</pre>
 <p><code>dec64_from_string</code> converts a zero-delimited string into a <code>dec64</code>. Separator
     characters will be ignored. If conversion is not possible for any reason,
-    the result will be <code>DEC64_NAN</code>.</p>
+    the result will be <code>DEC64_NULL</code>.</p>
 <pre>int <a id="dec64_to_string"><b>dec64_to_string</b></a>(
     dec64_string_state state,
     dec64 number,
@@ -316,7 +316,7 @@ dec64_to_string(state, dec64_new(1024, 0), string);</pre></td>
   </tr>
   <tr>
     <td><pre>dec64_from_string(state, &quot;1,024.0000&quot;)</pre></td>
-    <td><pre>DEC64_NAN</pre></td>
+    <td><pre>DEC64_NULL</pre></td>
   </tr>
   <tr>
     <td><pre>dec64_separator(state, ',');

--- a/dec64_string_test.c
+++ b/dec64_string_test.c
@@ -54,7 +54,7 @@ static dec64 negative_maxnum;
 static dec64 negative_pi;
 
 static void define_constants() {
-    nan = DEC64_NAN;                /* not a number */
+    nan = DEC64_NULL;               /* not a number */
     nannan = 32896;                 /* a non-normal nan */
     zero = DEC64_ZERO;              /* 0 */
     zip = 1;                        /* a non normal 0 */


### PR DESCRIPTION
These commits fix a couple of problem:

- dec64_round would get stuck in an infinite loop on UNIX systems.
- The antiquated DEC64_NAN constant was still being referenced by the math and string tests, preventing them from compiling.

A NASM port of dec64.asm is available at https://gist.github.com/jamesdiacono/bc9337520727876e09bafaf98225019c, which passes the tests on Linux and MacOS.

I also noticed there was a broken link on www.crockford.com/dec64.html. The text "It provides the DEC64 elementary operations." points to /dec64/dec64.obj.html, but it should point to /dec64.obj.html.